### PR TITLE
EASYOPAC-1008 - Refactor 'Read more' link.

### DIFF
--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -371,7 +371,8 @@ function ddbasic_preprocess__node__ding_campaign(&$variables) {
     switch ($type) {
       case 'image_and_text':
         $variables['image'] = '<div class="ding-campaign-image" style="background-image: url(' . $image_url . '"></div>';
-      break;
+        break;
+
       case 'image':
         if (!empty($variables['elements']['#widget_type']) && $variables['elements']['#widget_type'] == 'single') {
           $variables['image'] = theme('image', [
@@ -481,7 +482,7 @@ function ddbasic_preprocess__node__ding_page(&$variables) {
 
       if (!empty($variables['field_ding_page_list_image'][0]['uri'])) {
         $variables['background_image'] = image_style_url('ding_list_square', $variables['field_ding_page_list_image'][0]['uri']);
-      } 
+      }
       else {
         $variables['background_image'] = '';
       }

--- a/themes/ddbasic/templates/node/node--ding-eresource--view-mode--teaser.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-eresource--view-mode--teaser.tpl.php
@@ -92,7 +92,7 @@
     </div>
   </a>
   <div class="buttons">
-    <?php print l(t('Read more'), $node_url, array('attributes' => array('class' => array('read-more')))); ?>
+    <a href="<?php print $node_url; ?>" class="read-more"><?php print t('Read more'); ?></a>
     <?php if (!empty($link_url)) { ?>
       <a href="<?php print $link_url; ?>" class="log-on" target="_blank"><?php print t('Log on'); ?></a>
     <?php } ?>

--- a/themes/ddbasic/templates/node/node--ding-eresource--view-mode--teaser.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-eresource--view-mode--teaser.tpl.php
@@ -93,7 +93,7 @@
   </a>
   <div class="buttons">
     <a href="<?php print $node_url; ?>" class="read-more"><?php print t('Read more'); ?></a>
-    <?php if (!empty($link_url)) { ?>
+    <?php if (!empty($link_url)) {?>
       <a href="<?php print $link_url; ?>" class="log-on" target="_blank"><?php print t('Log on'); ?></a>
     <?php } ?>
   </div>


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1008

#### Description

"Read More" on /e-materialer page have duplicated language parameter in URL (/en/en/e-materialer/ereolen-1).

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.