### PR TITLE
AD-HOTFIX - Restore infomedia field definition.

### DIFF
--- a/modules/ting_infomedia/includes/ting_infomedia.field.inc
+++ b/modules/ting_infomedia/includes/ting_infomedia.field.inc
@@ -5,7 +5,8 @@
  */
 
 /**
- * This is updated from Barry Jaspan's presentation at Drupalcon Paris,
+ * This is updated from Barry Jaspan's presentation at Drupalcon Paris.
+ *
  * @link http://acquia.com/community/resources/acquia-tv/intro-field-api-module-developers Video Presentation @endlink
  *
  * Providing a field requires:
@@ -59,7 +60,7 @@ function ting_infomedia_field_formatter_info() {
       'field types' => array(
         'ting_infomedia',
       ),
-    )
+    ),
   );
 }
 
@@ -77,7 +78,7 @@ function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $ins
         foreach ($entity->relations as $relation) {
           if (isset($relation_types[$relation->type]) && $entity->ac_source == 'Artikler') {
             $element[$delta] = array(
-              '#markup' => l(t('Read article'), ting_infomedia_get_article_link($id), array('attributes' => array('class' => 'infomedia_group', 'name'=>$relation->type))),
+              '#markup' => l(t('Read article'), ting_infomedia_get_article_link($id), array('attributes' => array('class' => 'infomedia_group', 'name' => $relation->type))),
             );
           }
         }
@@ -141,7 +142,6 @@ function ting_infomedia_field_load($entity_type, $entities, $field, $instances, 
  * Notes: add the field to given item(s)
  * we could also use hook_field_load or hook_field_prepare_view.
  */
-
 function ting_infomedia_field_formatter_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items, $displays) {
   foreach ($entities as $id => $entity) {
     // We could create relations as multiple values here, but it's

--- a/modules/ting_infomedia/includes/ting_infomedia.field.inc
+++ b/modules/ting_infomedia/includes/ting_infomedia.field.inc
@@ -21,17 +21,10 @@
  * - Defining a widget for the edit form
  *   - hook_field_widget_info()
  *   - hook_field_widget_form()
- *
- * *
-
-/**
- * Implements hook_field_info()
-
- * description of field
  */
 
 /**
- * @TODO: Missing description.
+ * Implements hook_field_info().
  */
 function ting_infomedia_field_info() {
   $ret = array(
@@ -53,9 +46,9 @@ function ting_infomedia_field_info() {
 }
 
 /**
- * Implements hook_field_formatter_info
+ * Implements hook_field_formatter_info().
  *
- * Notes; 'field types' are passed on to hook_field_formatter_view
+ * Notes: 'field types' are passed on to hook_field_formatter_view.
  */
 function ting_infomedia_field_formatter_info() {
   return array(
@@ -69,7 +62,7 @@ function ting_infomedia_field_formatter_info() {
 }
 
 /**
- * Implements hook_field_formatter_view()
+ * Implements hook_field_formatter_view().
  */
 function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
   $element = array();
@@ -78,7 +71,7 @@ function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $ins
   $relation_types = ting_infomedia_get_ting_relations();
   switch($display['type']) {
     case 'ting_infomedia_default' :
-      foreach($items as $delta => $items) {
+      foreach($items as $delta => $item) {
         foreach ($entity->relations as $relation) {
           if(isset($relation_types[$relation->type]) && $entity->ac_source == 'Artikler' ) {
             $element[$delta] = array(
@@ -94,10 +87,12 @@ function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $ins
 }
 
 /**
- * Parse the entityid and return an url
+ * Parse the entityid and return an url.
  *
- * @param String $entityid
- * @return String
+ * @param string $entityid
+ *   Current entity id.
+ * @return string
+ *   Link to infomedia article.
  */
 function ting_infomedia_get_article_link($entityid) {
   $ids = explode(':', $entityid);
@@ -105,7 +100,7 @@ function ting_infomedia_get_article_link($entityid) {
 }
 
 /**
- * Implements hook_field_validate
+ * Implements hook_field_validate().
  *
  * @TODO is some kind of validation needed?
  */
@@ -114,9 +109,9 @@ function ting_infomedia_field_validate($entity_type, $entity, $field, $instance,
 }
 
 /**
- * Implements hook_field_is_empty
+ * Implements hook_field_is_empty().
  *
- * @TODO: check
+ * @TODO: check.
  */
 function ting_infomedia_is_empty($item, $field) {
   return false;
@@ -124,6 +119,7 @@ function ting_infomedia_is_empty($item, $field) {
 
 /**
  * Implements hook_field_load().
+ *
  * Notes: Define custom load behavior for this module's field types.
  */
 function ting_infomedia_field_load($entity_type, $entities, $field, $instances, $langcode, &$items, $age) {
@@ -137,9 +133,10 @@ function ting_infomedia_field_load($entity_type, $entities, $field, $instances, 
 }
 
 /**
- * Implements hook_field_formatter_prepare_view
- * Notes; add the field to given item(s)
- * we could also use hook_field_load or hook_field_prepare_view
+ * Implements hook_field_formatter_prepare_view().
+ *
+ * Notes: add the field to given item(s)
+ * we could also use hook_field_load or hook_field_prepare_view.
  */
 
 function ting_infomedia_field_formatter_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items, $displays) {

--- a/modules/ting_infomedia/includes/ting_infomedia.field.inc
+++ b/modules/ting_infomedia/includes/ting_infomedia.field.inc
@@ -73,7 +73,7 @@ function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $ins
 
   $relation_types = ting_infomedia_get_ting_relations();
   switch ($display['type']) {
-    case 'ting_infomedia_default' :
+    case 'ting_infomedia_default':
       foreach ($items as $delta => $item) {
         foreach ($entity->relations as $relation) {
           if (isset($relation_types[$relation->type]) && $entity->ac_source == 'Artikler') {

--- a/modules/ting_infomedia/includes/ting_infomedia.field.inc
+++ b/modules/ting_infomedia/includes/ting_infomedia.field.inc
@@ -2,7 +2,9 @@
 /**
  * @file
  * An example field using the Field API.
- *
+ */
+
+/**
  * This is updated from Barry Jaspan's presentation at Drupalcon Paris,
  * @link http://acquia.com/community/resources/acquia-tv/intro-field-api-module-developers Video Presentation @endlink
  *
@@ -69,11 +71,11 @@ function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $ins
   $id = $entity->ding_entity_id;
 
   $relation_types = ting_infomedia_get_ting_relations();
-  switch($display['type']) {
+  switch ($display['type']) {
     case 'ting_infomedia_default' :
-      foreach($items as $delta => $item) {
+      foreach ($items as $delta => $item) {
         foreach ($entity->relations as $relation) {
-          if(isset($relation_types[$relation->type]) && $entity->ac_source == 'Artikler' ) {
+          if (isset($relation_types[$relation->type]) && $entity->ac_source == 'Artikler') {
             $element[$delta] = array(
               '#markup' => l(t('Read article'), ting_infomedia_get_article_link($id), array('attributes' => array('class' => 'infomedia_group', 'name'=>$relation->type))),
             );
@@ -91,6 +93,7 @@ function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $ins
  *
  * @param string $entityid
  *   Current entity id.
+ *
  * @return string
  *   Link to infomedia article.
  */
@@ -105,7 +108,7 @@ function ting_infomedia_get_article_link($entityid) {
  * @TODO is some kind of validation needed?
  */
 function ting_infomedia_field_validate($entity_type, $entity, $field, $instance, $langcode, $items, &$errors) {
-  // do nothing
+  // Do nothing.
 }
 
 /**
@@ -114,7 +117,7 @@ function ting_infomedia_field_validate($entity_type, $entity, $field, $instance,
  * @TODO: check.
  */
 function ting_infomedia_is_empty($item, $field) {
-  return false;
+  return FALSE;
 }
 
 /**

--- a/modules/ting_infomedia/includes/ting_infomedia.field.inc
+++ b/modules/ting_infomedia/includes/ting_infomedia.field.inc
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @file
+ * An example field using the Field API.
+ *
+ * This is updated from Barry Jaspan's presentation at Drupalcon Paris,
+ * @link http://acquia.com/community/resources/acquia-tv/intro-field-api-module-developers Video Presentation @endlink
+ *
+ * Providing a field requires:
+ * - Defining a field
+ *   - hook_field_info()
+ *   - hook_field_schema()
+ *   - hook_field_validate()
+ *   - hook_field_is_empty()
+ *
+ * - Defining a formatter for the field (the portion that outputs the field for
+ *   display)
+ *   - hook_field_formatter_info()
+ *   - hook_field_formatter_view()
+ *
+ * - Defining a widget for the edit form
+ *   - hook_field_widget_info()
+ *   - hook_field_widget_form()
+ *
+ * *
+
+/**
+ * Implements hook_field_info()
+
+ * description of field
+ */
+
+/**
+ * @TODO: Missing description.
+ */
+function ting_infomedia_field_info() {
+  $ret = array(
+    'ting_infomedia' => array(
+      'label' => t('A link to infomedia articles'),
+      'description' => t('This field links to infomedia articles'),
+      'settings' => array(
+        'max_length' => 255,
+      ),
+      'default_widget' => 'hidden',
+      'default_formatter' => 'ting_infomedia_default',
+      'virtual_field' => array(
+        'entity_types' => array('ting_object'),
+        'add_widget' => TRUE,
+      ),
+    ),
+  );
+  return $ret;
+}
+
+/**
+ * Implements hook_field_formatter_info
+ *
+ * Notes; 'field types' are passed on to hook_field_formatter_view
+ */
+function ting_infomedia_field_formatter_info() {
+  return array(
+    'ting_infomedia_default' => array(
+      'label' => t('Default'),
+      'field types' => array(
+        'ting_infomedia',
+      ),
+    )
+  );
+}
+
+/**
+ * Implements hook_field_formatter_view()
+ */
+function ting_infomedia_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  $element = array();
+  $id = $entity->ding_entity_id;
+
+  $relation_types = ting_infomedia_get_ting_relations();
+  switch($display['type']) {
+    case 'ting_infomedia_default' :
+      foreach($items as $delta => $items) {
+        foreach ($entity->relations as $relation) {
+          if(isset($relation_types[$relation->type]) && $entity->ac_source == 'Artikler' ) {
+            $element[$delta] = array(
+              '#markup' => l(t('Read article'), ting_infomedia_get_article_link($id), array('attributes' => array('class' => 'infomedia_group', 'name'=>$relation->type))),
+            );
+          }
+        }
+      }
+      break;
+  }
+
+  return $element;
+}
+
+/**
+ * Parse the entityid and return an url
+ *
+ * @param String $entityid
+ * @return String
+ */
+function ting_infomedia_get_article_link($entityid) {
+  $ids = explode(':', $entityid);
+  return 'ting/infomedia/' . $ids[1];
+}
+
+/**
+ * Implements hook_field_validate
+ *
+ * @TODO is some kind of validation needed?
+ */
+function ting_infomedia_field_validate($entity_type, $entity, $field, $instance, $langcode, $items, &$errors) {
+  // do nothing
+}
+
+/**
+ * Implements hook_field_is_empty
+ *
+ * @TODO: check
+ */
+function ting_infomedia_is_empty($item, $field) {
+  return false;
+}
+
+/**
+ * Implements hook_field_load().
+ * Notes: Define custom load behavior for this module's field types.
+ */
+function ting_infomedia_field_load($entity_type, $entities, $field, $instances, $langcode, &$items, $age) {
+  foreach ($entities as $id => $entity) {
+    // We could create relations as multiple values here, but it's
+    // cached after this hook, so we don't.
+    $items[$id][0] = array(
+      'id' => $id,
+    );
+  }
+}
+
+/**
+ * Implements hook_field_formatter_prepare_view
+ * Notes; add the field to given item(s)
+ * we could also use hook_field_load or hook_field_prepare_view
+ */
+
+function ting_infomedia_field_formatter_prepare_view($entity_type, $entities, $field, $instances, $langcode, &$items, $displays) {
+  foreach ($entities as $id => $entity) {
+    // We could create relations as multiple values here, but it's
+    // cached after this hook, so we don't.
+    $items[$id][0] = array(
+      'id' => $id,
+    );
+  }
+}

--- a/modules/ting_infomedia/ting_infomedia.module
+++ b/modules/ting_infomedia/ting_infomedia.module
@@ -7,6 +7,7 @@
 
 // Load field hooks.
 module_load_include('inc', 'ting_infomedia', 'includes/ting_infomedia.wrapper');
+module_load_include('inc', 'ting_infomedia', 'includes/ting_infomedia.field');
 
 /**
  * Implements hook_menu().


### PR DESCRIPTION
#### Description

Because of missing ting_infomedia field's definition, easyOpac site on v4.5 was failing with fatal error.
Here was restored previously removed ting_infomedia.fields.inc file which contains all data for this field.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.