### PR TITLE
AD-Hotfix - Restore infomedia field formatter.

### DIFF
--- a/modules/ting_infomedia/ting_infomedia.install
+++ b/modules/ting_infomedia/ting_infomedia.install
@@ -47,3 +47,14 @@ function ting_infomedia_update_7000() {
 function ting_infomedia_update_7001() {
   ding_entity_unlock_fields('ting_infomedia', array('ting_infomedia'));
 }
+
+/**
+ * Remove ting_infomedia field.
+ */
+function ting_infomedia_update_7002() {
+  $field_info = field_info_field('ting_infomedia');
+
+  if (!empty($field_info)) {
+    field_delete_field($field_info['field_name']);
+  }
+}

--- a/modules/ting_infomedia/ting_infomedia.module
+++ b/modules/ting_infomedia/ting_infomedia.module
@@ -37,6 +37,44 @@ function ting_infomedia_menu() {
 }
 
 /**
+ * Implements hook_field_info().
+ */
+function ting_infomedia_field_info() {
+  $ret = array(
+    'ting_infomedia' => array(
+      'label' => t('A link to infomedia articles'),
+      'description' => t('This field links to infomedia articles'),
+      'settings' => array(
+        'max_length' => 255,
+      ),
+      'default_widget' => 'hidden',
+      'default_formatter' => 'ting_infomedia_default',
+      'virtual_field' => array(
+        'entity_types' => array('ting_object'),
+        'add_widget' => TRUE,
+      ),
+    ),
+  );
+  return $ret;
+}
+
+/**
+ * Implements hook_field_formatter_info().
+ *
+ * Notes: 'field types' are passed on to hook_field_formatter_view.
+ */
+function ting_infomedia_field_formatter_info() {
+  return array(
+    'ting_infomedia_default' => array(
+      'label' => t('Default'),
+      'field types' => array(
+        'ting_infomedia',
+      ),
+    ),
+  );
+}
+
+/**
  * Page callback function.
  *
  * @return array

--- a/modules/ting_infomedia/ting_infomedia.module
+++ b/modules/ting_infomedia/ting_infomedia.module
@@ -37,44 +37,6 @@ function ting_infomedia_menu() {
 }
 
 /**
- * Implements hook_field_info().
- */
-function ting_infomedia_field_info() {
-  $ret = array(
-    'ting_infomedia' => array(
-      'label' => t('A link to infomedia articles'),
-      'description' => t('This field links to infomedia articles'),
-      'settings' => array(
-        'max_length' => 255,
-      ),
-      'default_widget' => 'hidden',
-      'default_formatter' => 'ting_infomedia_default',
-      'virtual_field' => array(
-        'entity_types' => array('ting_object'),
-        'add_widget' => TRUE,
-      ),
-    ),
-  );
-  return $ret;
-}
-
-/**
- * Implements hook_field_formatter_info().
- *
- * Notes: 'field types' are passed on to hook_field_formatter_view.
- */
-function ting_infomedia_field_formatter_info() {
-  return array(
-    'ting_infomedia_default' => array(
-      'label' => t('Default'),
-      'field types' => array(
-        'ting_infomedia',
-      ),
-    ),
-  );
-}
-
-/**
  * Page callback function.
  *
  * @return array


### PR DESCRIPTION
#### Description

On some site ting_infomedia field is missing a field formatter, the fact that is generating fatal errors.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.