### PR TITLE
NO-TASK-NG - Consider scss files from modules.

### DIFF
--- a/themes/ddbasic/gulpfile.js
+++ b/themes/ddbasic/gulpfile.js
@@ -16,8 +16,13 @@ var argv = require('yargs').argv;
 
 // We only want to process our own non-processed JavaScript files.
 // var jsPath = './scripts/ddbasic.!(*.min).js';
+
 var jsPath = ['./scripts/**/*.js', '!./scripts/contrib/*', '!./scripts/min/**/*.js'];
 var sassPath = ['./sass/**/*.scss', '!./sass/contrib/**'];
+var modules = [
+  '../../modules/easyopac_facetbrowser_extend/scss/easyopac_facetbrowser_extend.scss'
+];
+sassPath = sassPath.concat(modules);
 
 gulp.task('jshint', 'Run Javascript through JSHint',
   function() {


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

If we add in a easyOPAC module some styles currently we have 2 options. 1) clean css 2) use some compiler(most of our modules use compass).
With these options we are limited to the base color of the them, so we are forced to make some hacking in order to get theme color scheme.
With this commit we allow the gulp compiler to get styles from the module and add them to the them. It is still a work in progress, but from POW it will be much easier for the development.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
