### PR TITLE
1404 more migration fixes

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -390,22 +390,29 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
     case 'ding_p2b':
       if (!empty($items)) {
         $settings = reset($items);
-        if ($settings['synchronize']) {
-          if (empty($settings['event_id'])) {
-            $items = _ding_place2book_create_p2b_entities($entity, $settings);
+        // Ensure that 'capacity' key exists before trying to synchronize the
+        // event with p2b. It's required by the API and if not set. This also
+        // protects against unneeded request against API, since this key will be
+        // here when updating node from a form, but not when a node is updated
+        // programmatically.
+        if (array_key_exists('capacity', $settings)) {
+          if ($settings['synchronize']) {
+            if (empty($settings['event_id'])) {
+              $items = _ding_place2book_create_p2b_entities($entity, $settings);
+            }
+            else {
+              $items = _ding_place2book_update_p2b_entities($entity, $settings);
+            }
           }
           else {
-            $items = _ding_place2book_update_p2b_entities($entity, $settings);
+            $items = array(
+              array(
+                'event_id' => $settings['event_id'],
+                'event_maker_id' => $settings['event_maker_id'],
+                'synchronize' => $settings['synchronize'],
+              ),
+            );
           }
-        }
-        else {
-          $items = array(
-            array(
-              'event_id' => $settings['event_id'],
-              'event_maker_id' => $settings['event_maker_id'],
-              'synchronize' => $settings['synchronize'],
-            ),
-          );
         }
       }
       break;

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
@@ -61,7 +61,7 @@ function _ding_place2book_migrate_batch($events, &$context) {
       // wrapper, when field data is not available.
       // See: https://www.drupal.org/project/entity/issues/1596594
       if (field_get_items('node', $node, 'field_ding_event_ticket_link')) {
-        $node_wrapper =  entity_metadata_wrapper('node', $node);
+        $node_wrapper = entity_metadata_wrapper('node', $node);
         $ticket_url = $node_wrapper->field_ding_event_ticket_link->url->value();
         if (strpos($ticket_url, 'https://www.place2book.com') === 0) {
           $node_wrapper->field_ding_event_ticket_link->set(NULL);

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
@@ -36,13 +36,38 @@ function _ding_place2book_migrate_batch($events, &$context) {
   $context['sandbox']['progress'] += count($part);
   foreach ($part as $event) {
     $node = node_load($event->nid);
-    $event_maker_id = _ding_place2book_get_event_maker($node);
     if (!empty($event->place2book_id) && $event->place2book_id != -1) {
+      $event_maker_id = _ding_place2book_get_event_maker($node);
+
+      // Migrate the node's p2b event data to the new p2b field.
       $node->field_place2book[LANGUAGE_NONE][0] = array(
         'event_id' => $event->place2book_id,
         'event_maker_id' => $event_maker_id,
         'synchronize' => $event->maintain_copy,
       );
+
+      // In the old version of p2b integration module, the field for external
+      // ticket link was used by p2b also. In the new version the module has
+      // it's own dedicated field with widget and formatter, and the formatter
+      // outputs its own ticket link button. Unfortunately this will result in
+      // double ticket buttons in frontend for migrated events, since they will
+      // still have the p2b ticket URL in the ticket_link field. The easiest
+      // solution at this point seems to be to keep the fields separated, so
+      // here we ensure that existing nodes with p2b data don't also have the
+      // p2b ticket URL in the ticket_link field, to avoid double ticket buttons
+      // in frontend.
+      // Note that the initial field_get_items check is used to avoid having to
+      // deal with the "Parent Data Structure Not Set" exception thrown by the
+      // wrapper, when field data is not available.
+      // See: https://www.drupal.org/project/entity/issues/1596594
+      if (field_get_items('node', $node, 'field_ding_event_ticket_link')) {
+        $node_wrapper =  entity_metadata_wrapper('node', $node);
+        $ticket_url = $node_wrapper->field_ding_event_ticket_link->url->value();
+        if (strpos($ticket_url, 'https://www.place2book.com') === 0) {
+          $node_wrapper->field_ding_event_ticket_link->set(NULL);
+        }
+      }
+
       node_save($node);
     }
     $context['message'] = t('Processing: <em>@title</em> (@current/@total).', array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1404

#### Description

Some more migration fixes.

During migration I got a lot of: `Error. updateEvent requires: [capacity]`
As it turns out, this is because the field_presave hook tries to sync with p2b API even when nodes are updated programmatically as in the migration. The easiest fix for this for both of these issues, seems to be checking for the precence of the capacity key in presave hook. It should still be possible to sync the node with p2b programmatically, one will just have to supply the capacity manually in the field item.

Also includes a fix the double ticket link in frontend issue, by ensuring that the p2b URL is remove from the external ticket_link field, since p2b now supplies it's field formatter which outputs its own field.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
