### PR TITLE
1404: Better handling of events with sold tickets

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -425,7 +425,7 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
 }
 
 /**
- * Implements hook_field_delete()
+ * Implements hook_field_delete().
  */
 function ding_place2book_field_delete($entity_type, $entity, $field, $instance, $langcode, &$items) {
   switch ($field['type']) {

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -425,6 +425,37 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
 }
 
 /**
+ * Implements hook_field_delete()
+ */
+function ding_place2book_field_delete($entity_type, $entity, $field, $instance, $langcode, &$items) {
+  switch ($field['type']) {
+    case 'ding_p2b':
+      if (!empty($items)) {
+        $settings = reset($items);
+        if ($settings['synchronize'] && !empty($settings['event_id'])) {
+          $event_id = $settings['event_id'];
+          $event_maker_id = $settings['event_maker_id'];
+          try {
+            $p2b = ding_place2book_instance();
+            $prices = $p2b->getPrices($event_maker_id, $event_id);
+            foreach ($prices as $price) {
+              $p2b->deletePrice($event_maker_id, $event_id, $price->id);
+            }
+            $p2b->deleteEvent($event_maker_id, $event_id);
+          }
+          catch (Exception $ex) {
+            watchdog_exception('ding_place2book', $ex, t('Error appeared on deleting node: nid - :nid, title - :title.', array(
+              ':nid' => $node->nid,
+              ':title' => $node->title,
+            )));
+          }
+        }
+      }
+      break;
+  }
+}
+
+/**
  * Implements hook_field_formatter_info().
  */
 function ding_place2book_field_formatter_info() {

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -218,6 +218,10 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#default_value' => !empty($price) ? $price->name : $price_name,
         );
 
+        if (!empty($price->sold_tickets)) {
+          $element['place2book']['prices_wrapper']['prices'][$key]['name']['#description'] = t('NB: This ticket type has sold tickets and can not be removed.');
+        }
+
         $element['place2book']['prices_wrapper']['prices'][$key]['value'] = array(
           '#type' => 'textfield',
           '#default_value' => !empty($price) ? $price->value : '',
@@ -250,6 +254,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#event_maker_id' => $event_maker_id,
           '#submit' => array('ding_place2book_prices_remove_submit'),
           '#limit_validation_errors' => array(),
+          '#disabled' => !empty($price->sold_tickets),
           '#ajax' => array(
             'wrapper' => 'ding-place2book-prices-wrapper',
             'callback' => 'ding_p2b_prices_remove_ajax_handler',

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -239,32 +239,6 @@ function ding_p2b_format_options($node, array $additional) {
 }
 
 /**
- * Implements hook_node_delete().
- */
-function ding_place2book_node_delete($node) {
-  if ($node->type == 'ding_event') {
-    $field_place2book = field_get_items('node', $node, 'field_place2book');
-    if (!empty($field_place2book)) {
-      list($event_id, $event_maker_id) = array_values($field_place2book[0]);
-      try {
-        $p2b = ding_place2book_instance();
-        $prices = $p2b->getPrices($event_maker_id, $event_id);
-        foreach ($prices as $price) {
-          $p2b->deletePrice($event_maker_id, $event_id, $price->id);
-        }
-      }
-      catch (Exception $ex) {
-        watchdog_exception('ding_place2book', $ex, t('Error appeared on deleting node: nid - :nid, title - :title.', array(
-          ':nid' => $node->nid,
-          ':title' => $node->title,
-        )));
-      }
-      $p2b->deleteEvent($event_maker_id, $event_id);
-    }
-  }
-}
-
-/**
  * Collects address data from referenced library or current node.
  *
  * @param object $node


### PR DESCRIPTION
Adds better handling of deletion of ticket types with sold tickets, by disabling the remove-button when this is the case. Also adds a note at the ticket type explaining why deletion is disabled.

@guddo We should have a talk about how to handle deletion of nodes (ding_event) with ticket types with sold tickets.

Note: I also sneaked in a small correction: The logic handling node/entity deletion is moved to the dedicated field hook (hook_field_delete). Since it's a field it's more correct to handle it here, will make it independent on which node/node_type/entity, the field is attached too.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
