### PR TITLE
EASYOPAC-1032 - Don't enable Custom CSS module on enable.

### DIFF
--- a/modules/ding_sections/ding_sections.install
+++ b/modules/ding_sections/ding_sections.install
@@ -20,7 +20,6 @@ function ding_sections_install() {
   ));
 
   $submodules = array(
-    'ding_sections_custom_css',
     'ding_sections_term_menu',
     'ding_sections_term_panel',
   );


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1032

#### Description

Removed "ding_sections_custom_css" module from being enabled on "ding_sections" module installation.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.