### PR TITLE
EASYOPAC-1030 - Migrate ting_searches to the searches settings.

### DIFF
--- a/modules/ting_search_carousel/ting_search_carousel.install
+++ b/modules/ting_search_carousel/ting_search_carousel.install
@@ -66,7 +66,7 @@ function ting_search_carousel_update_7101() {
 
   foreach ($query->execute() as $pane) {
     $configuration = unserialize($pane->configuration);
-    $configuration['searches'] = variable_get('ting_carousel_search_queries', array());
+    $configuration['searches'] = array_merge($configuration['ting_searches'], variable_get('ting_carousel_search_queries', array()));
     $configuration['settings'] = array(
       'transition' => variable_get('ting_search_carousel_transition', 'fade'),
     );


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1030

#### Description

Update the migration process so the ting_search_carousels settings are kept in the database.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/3027336/53956157-884cd000-40e3-11e9-9857-20cfb50996f1.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR will need to be reverted in future version
