### PR TITLE
EASYOPAC-1051 - Sections: Check if field_term_page exists.

### DIFF
--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
@@ -9,7 +9,11 @@
  * Implements hook_install().
  */
 function ding_sections_term_panel_install() {
-  ding_sections_term_panel_create_fields();
+  $term_page_field = field_info_instance('taxonomy_term', 'field_term_page', 'section');
+
+  if (empty($term_page_field)) {
+    ding_sections_term_panel_create_fields();
+  }
   ding_sections_term_panel_create_variant();
 }
 


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1051

#### Description

On site build is running ding_update_7063 which is enabling ding_sections module and its submodules. The module ding_sections_term_panel is also installed and this tries to create field_term_page field in the database, which in case we already had easyddb_editorialbase_term_panel module enabled, was already created.
This commit adds additional check on module enable so we don't have conflicts regarding already existing field.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
