### PR TITLE
 Hotfix: Build fails when ding_social rules are reverted.

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -79,8 +79,8 @@ projects[email][version] = "1.3"
 
 projects[entity][subdir] = "contrib"
 projects[entity][version] = "1.8"
-; https://www.drupal.org/project/rules/issues/1309144
-projects[entity][patch][0] = "https://www.drupal.org/files/issues/entity-1309144-24-7.x-2.x.patch"
+; https://www.drupal.org/node/2829437
+projects[entity][patch][0] = "https://www.drupal.org/files/issues/entity-rebuild-2829437-4.patch"
 
 projects[entitycache][subdir] = "contrib"
 projects[entitycache][version] = "1.2"

--- a/ding2.make
+++ b/ding2.make
@@ -79,6 +79,8 @@ projects[email][version] = "1.3"
 
 projects[entity][subdir] = "contrib"
 projects[entity][version] = "1.8"
+; https://www.drupal.org/project/rules/issues/1309144
+projects[entity][patch][0] = "https://www.drupal.org/files/issues/entity-1309144-24-7.x-2.x.patch"
 
 projects[entitycache][subdir] = "contrib"
 projects[entitycache][version] = "1.2"


### PR DESCRIPTION
#### Description

Site build fails because of impossibility of features module to import rules exported into ding_social module.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.