### PR TITLE
EASYOPAC-1072 - Anchors not following viewport of content.

### DIFF
--- a/themes/ddbasic/scripts/ddbasic.common.js
+++ b/themes/ddbasic/scripts/ddbasic.common.js
@@ -192,4 +192,39 @@
     }
   };
 
+  /**
+   * Make clicks on anchor links to stop on correct position.
+   */
+  Drupal.behaviors.findTopForAnchor = {
+    attach: function (context, settings) {
+      var offset = $('#page')[0].offsetTop;
+      var queryString = window.location.hash;
+
+      if (queryString !== "") {
+        scrollToAnchor(queryString);
+      }
+
+      $('article a[href^="#"]').click(function (event) {
+        event.preventDefault();
+        var anchorId = $(this).attr('href');
+        scrollToAnchor(anchorId);
+        return false;
+      });
+
+      function scrollToAnchor(anchorId) {
+        var target, anchorObject = $(anchorId);
+        if (anchorObject.length !== 0) {
+          target = anchorObject.offset().top - offset - 61;
+        }
+        else {
+          return false;
+        }
+
+        $('html, body').animate({scrollTop: target}, 'fast', function () {
+          window.location.hash = anchorId;
+        });
+      }
+    }
+  }
+
 })(jQuery);

--- a/themes/ddbasic/scripts/ddbasic.common.js
+++ b/themes/ddbasic/scripts/ddbasic.common.js
@@ -200,17 +200,6 @@
       var offset = $('#page')[0].offsetTop;
       var queryString = window.location.hash;
 
-      if (queryString !== "") {
-        scrollToAnchor(queryString);
-      }
-
-      $('article a[href^="#"]').click(function (event) {
-        event.preventDefault();
-        var anchorId = $(this).attr('href');
-        scrollToAnchor(anchorId);
-        return false;
-      });
-
       function scrollToAnchor(anchorId) {
         var target, anchorObject = $(anchorId);
         if (anchorObject.length !== 0) {
@@ -224,7 +213,18 @@
           window.location.hash = anchorId;
         });
       }
+
+      if (queryString !== "") {
+        scrollToAnchor(queryString);
+      }
+
+      $('article a[href^="#"]').click(function (event) {
+        event.preventDefault();
+        var anchorId = $(this).attr('href');
+        scrollToAnchor(anchorId);
+        return false;
+      });
     }
-  }
+  };
 
 })(jQuery);


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1072

#### Description

Click on anchor links are not listening for page header height so the content to which page is scrolled is not visible.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.