### PR TITLE
EASYOPAC-1073 - Use kr. instead of Kr.

### DIFF
--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -124,7 +124,7 @@ function ding_debt_form_details(&$form, $debts, $has_invoiced_fees, $total_amoun
         ),
         'amount' => array(
           'label' => t('Amount'),
-          'data' => $debt->is_invoice ? number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('Kr') . ' <span class="note">*</span>' : number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('Kr'),
+          'data' => $debt->is_invoice ? number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('kr.') . ' <span class="note">*</span>' : number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t(''),
           'class' => 'fee_amount',
           '#weight' => 8,
         ),
@@ -151,7 +151,7 @@ function ding_debt_form_details(&$form, $debts, $has_invoiced_fees, $total_amoun
     '#type' => 'item',
     '#prefix' => '<div class="total-amount">',
     '#suffix' => '</div>',
-    '#markup' => t('Total') . ': <span class="amount">' . number_format($total_amount, 2, ',', ' ') . ' ' . t('Kr') . '</span>',
+    '#markup' => t('Total') . ': <span class="amount">' . number_format($total_amount, 2, ',', ' ') . ' ' . t('kr.') . '</span>',
   );
 
   if ($has_invoiced_fees) {

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -124,7 +124,7 @@ function ding_debt_form_details(&$form, $debts, $has_invoiced_fees, $total_amoun
         ),
         'amount' => array(
           'label' => t('Amount'),
-          'data' => $debt->is_invoice ? number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('kr.') . ' <span class="note">*</span>' : number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t(''),
+          'data' => $debt->is_invoice ? number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('kr.') . ' <span class="note">*</span>' : number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('kr.'),
           'class' => 'fee_amount',
           '#weight' => 8,
         ),

--- a/modules/ding_dibs/ding_dibs.admin.inc
+++ b/modules/ding_dibs/ding_dibs.admin.inc
@@ -44,7 +44,7 @@ function ding_dibs_admin_settings($form, &$form_state) {
         Once the fee is paid, it is not possible to cancel the payment.<br/>
         The amount is not withdrawn from the account, until it is confirmed that the amount owed is paid in local system.<br/>
         Please note: PBS charges a transaction fee to handle your payment. The amount is 1.45 kr. + 0.1% of the fee.<br/>
-        For example: A fee of 15.00 kr. rises for PBS to 16.47 Kr.'),
+        For example: A fee of 15.00 kr. rises for PBS to 16.47 kr.'),
     '#suffix' => '</div>',
   );
 

--- a/modules/ding_event/ding_event.admin.inc
+++ b/modules/ding_event/ding_event.admin.inc
@@ -14,7 +14,7 @@
  * @return mixed
  */
 function ding_event_admin_setting_form(array $form, array &$form_state) {
-  $currency = variable_get('ding_event_currency_type', 'Kr');
+  $currency = variable_get('ding_event_currency_type', 'kr.');
   $form['#submit'][] = 'ding_event_admin_submit';
 
   $form['ding_event']['ding_event_currency_type'] = array(

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -424,7 +424,7 @@ function ding_event_metatag_metatags_view_alter(&$output, $instance, $options) {
     // Price.
     $price = field_get_items('node', $node, 'field_ding_event_price', 'value');
     if (!empty($price)) {
-      $metatag['price_out'] = $price[0]['value'] . ' ' . variable_get('ding_event_currency_type', 'Kr');
+      $metatag['price_out'] = $price[0]['value'] . ' ' . variable_get('ding_event_currency_type', 'kr.');
     }
 
     $output['description']['#attached']['drupal_add_html_head'][0][0]['#value'] = implode(', ', array_filter($metatag));

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1879,7 +1879,7 @@ function ding_nodelist_preprocess(&$variables, $hook) {
         $items[$key]->price = t('Free');
         if (is_array($fee_field)) {
           $fee = current($fee_field);
-          $items[$key]->price = $fee['value'] . ' ' . variable_get('ding_event_currency_type', 'Kr');
+          $items[$key]->price = $fee['value'] . ' ' . variable_get('ding_event_currency_type', 'kr.');
         }
       }
 

--- a/modules/ding_nodelist/translations/da.po
+++ b/modules/ding_nodelist/translations/da.po
@@ -475,7 +475,7 @@ msgstr "Gør det muligt at lave yderst tilpassede lister af indhold"
 #: profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php:30
 #: profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.taxonomy.tpl.php:59
 msgid "kr."
-msgstr ""
+msgstr "kr."
 
 #: profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php:41
 #: profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.image_text.tpl.php:48

--- a/modules/ding_nodelist/translations/general.pot
+++ b/modules/ding_nodelist/translations/general.pot
@@ -446,7 +446,7 @@ msgstr ""
 
 #: profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php:38 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.image_text.tpl.php:45 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.single.tpl.php:42 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php:30 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.taxonomy.tpl.php:59
 msgid "kr."
-msgstr ""
+msgstr "kr."
 
 #: profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php:41 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.image_text.tpl.php:48 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.single.tpl.php:45 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php:33 profiles/ding2/modules/ding_nodelist/templates/ding_nodelist.ding_event.taxonomy.tpl.php:62
 msgid "Free"

--- a/modules/ding_place2book/includes/ding_place2book.event_validate.inc
+++ b/modules/ding_place2book/includes/ding_place2book.event_validate.inc
@@ -15,9 +15,9 @@ function ding_place2book_form_ding_event_admin_currency_setting_form_alter(&$for
  */
 function ding_place2book_form_ding_event_admin_currency_setting_validate($form, &$form_state){
   $currency = $form_state['values']['ding_event_currency_type'];
-  if (module_exists('ding_place2book') && $currency != 'kr') {
+  if (module_exists('ding_place2book') && $currency != 'kr.') {
     drupal_set_message(t('place2book does not support currencies other than Kr. disable ding_place2book module to continue'), 'warning');
-    $form_state['input']['ding_event_currency_type'] = 'kr';
+    $form_state['input']['ding_event_currency_type'] = 'kr.';
     $form_state['rebuild'] = TRUE;
     return;
   }

--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -173,7 +173,7 @@ function ddbasic_preprocess__node__ding_event(&$variables) {
 
   $price = field_get_items('node', $variables['node'], 'field_ding_event_price');
   if (!empty($price)) {
-    $variables['event_price'] = $price[0]['value'] . ' ' . variable_get('ding_event_currency_type', 'Kr');
+    $variables['event_price'] = $price[0]['value'] . ' ' . variable_get('ding_event_currency_type', 'kr.');
   }
   else {
     $variables['event_price'] = t('Free');

--- a/themes/ddbasic/templates/node--newsletter.tpl.php
+++ b/themes/ddbasic/templates/node--newsletter.tpl.php
@@ -139,7 +139,7 @@
             <div class="event-date">
               <?php print $event->date; ?>
               <?php if (isset($event->fee)) :?>
-                - <?php print $event->fee; ?> KR.
+                - <?php print $event->fee; ?> kr.
               <?php endif; ?>
             </div>
           </div>

--- a/translations/da.po
+++ b/translations/da.po
@@ -9900,8 +9900,8 @@ msgid "JS Logout AHAH Set Last"
 msgstr ""
 
 #: /user/6/status/debts
-msgid "Kr"
-msgstr "Kr"
+msgid "kr."
+msgstr "kr."
 
 #: /user/6/status/debts
 msgid "Total"
@@ -53534,7 +53534,7 @@ msgid "Terms of sale (%language_name)"
 msgstr ""
 
 #: /admin/config/payment/ding_dibs?render=overlay
-msgid "\" n\"        For instance:<br/> n\"        The debt is paid in full to: [name] library, [adress], \"[email], CVR no. [number].<br/> n\"        Once the fee is paid, it is not possible to cancel the \"payment.<br/> n\"        The amount is not withdrawn from the account, until it is \"confirmed that the amount owed is paid in local system.<br/> n\"        Please note: PBS charges a transaction fee to handle your \"payment. The amount is 1.45 kr. + 0.1% of the fee.<br/> n\"        For example: A fee of 15.00 kr. rises for PBS to 16.47 Kr."
+msgid "\" n\"        For instance:<br/> n\"        The debt is paid in full to: [name] library, [adress], \"[email], CVR no. [number].<br/> n\"        Once the fee is paid, it is not possible to cancel the \"payment.<br/> n\"        The amount is not withdrawn from the account, until it is \"confirmed that the amount owed is paid in local system.<br/> n\"        Please note: PBS charges a transaction fee to handle your \"payment. The amount is 1.45 kr. + 0.1% of the fee.<br/> n\"        For example: A fee of 15.00 kr. rises for PBS to 16.47 kr."
 msgstr ""
 
 #: /admin/config/payment/ding_dibs?render=overlay


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1073

#### Description

Several places I have seen "Kr" shown to the user instead of "kr.".

Please find out where this is happening and if its in code then change it, and if its a setting or in DB - let me know.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.