### PR TITLE
EASYOPAC-1071 - Consider only pane subtype machine name.

### DIFF
--- a/modules/ding_ipe_filter/ding_ipe_filter.install
+++ b/modules/ding_ipe_filter/ding_ipe_filter.install
@@ -85,3 +85,24 @@ function ding_ipe_filter_update_7103(&$sandbox) {
     variable_set('ding_ipe_filter_panes_selected', $selected);
   }
 }
+
+/**
+ * Remove category from selection identifiers.
+ */
+function ding_ipe_filter_update_7104(&$sandbox) {
+  /**
+   * Category key is loaded based on the active language. It needs to have the
+   * same set for all languages. Uniqueness is kept based on the pane sub-type.
+   */
+  $selected = _ding_ipe_filter_selected_panes();
+  $new_selections = array();
+  foreach ($selected as $value) {
+    $matches = array();
+    preg_match('/(\S+):(\S+)/', $value, $matches);
+    if (!empty($matches[2])) {
+      $new_selections[$matches[2]] = $matches[2];
+    }
+  }
+
+  variable_set('ding_ipe_filter_panes_selected', $new_selections);
+}

--- a/modules/ding_ipe_filter/ding_ipe_filter.install
+++ b/modules/ding_ipe_filter/ding_ipe_filter.install
@@ -90,7 +90,7 @@ function ding_ipe_filter_update_7103(&$sandbox) {
  * Remove category from selection identifiers.
  */
 function ding_ipe_filter_update_7104(&$sandbox) {
-  /**
+  /*
    * Category key is loaded based on the active language. It needs to have the
    * same set for all languages. Uniqueness is kept based on the pane sub-type.
    */

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -212,8 +212,6 @@ function _ding_ipe_filter_show_for_admin() {
 /**
  * Get the current filter list.
  *
-
- *
  * @return array
  *   The selected panes indexed by "category:subtype-name".
  */

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -144,8 +144,7 @@ function _ding_ipe_filter_callback($variables = array()) {
     // Filter panes available based on the configuration.
     $selections = _ding_ipe_filter_selected_panes();
     foreach ($selections as $selection) {
-      list($category, $subtype_name) = explode(':', $selection);
-      $pane = _ding_ipe_filter_get_pane_info($category, $subtype_name);
+      $pane = _ding_ipe_filter_get_pane_info($selection);
       if (is_array($pane)) {
         $url = $variables['renderer']->get_url('add-pane', $region_id, $pane['type_name'], $pane['subtype_name']);
         $output['#selections']['#items'][] = l(t($pane['title']), $url, array(
@@ -166,15 +165,13 @@ function _ding_ipe_filter_callback($variables = array()) {
  * This is also used to check if a given pane is available in the current
  * codebase, hence preventing the user form adding old removed panel panes.
  *
- * @param string $category
- *   The pane category to find the pane.
  * @param string $subtype_name
  *   The panes subtype name used to identify the pane.
  *
  * @return array|bool
  *   If pane information is found an array with the information else FALSE.
  */
-function _ding_ipe_filter_get_pane_info($category, $subtype_name) {
+function _ding_ipe_filter_get_pane_info($subtype_name) {
   $categories = &drupal_static(__FUNCTION__);
   if (!isset($categories)) {
     ctools_include('content');
@@ -183,8 +180,8 @@ function _ding_ipe_filter_get_pane_info($category, $subtype_name) {
     $categories = $panel_editor->get_categories($content_types);
   }
 
-  if (!empty($categories[$category]['content'])) {
-    foreach ($categories[$category]['content'] as $pane) {
+  foreach ($categories as $category) {
+    foreach ($category['content'] as $pane) {
       if ($pane['subtype_name'] == $subtype_name) {
         return $pane;
       }
@@ -215,27 +212,26 @@ function _ding_ipe_filter_show_for_admin() {
 /**
  * Get the current filter list.
  *
- * The panel panes selected in the administration UI and if not configured yet
- * the default selections is used.
+
  *
  * @return array
  *   The selected panes indexed by "category:subtype-name".
  */
 function _ding_ipe_filter_selected_panes() {
   $default = array(
-    'ding-:ding_item_list' => 'ding-:ding_item_list',
-    'ding-:single_campaign' => 'ding-:single_campaign',
-    'miscellaneous:ding_event_calendar-ding-event-calendar' => 'miscellaneous:ding_event_calendar-ding-event-calendar',
-    'ding-:ding_nodelist' => 'ding-:ding_nodelist',
-    'ding-:all_opening_hours' => 'ding-:all_opening_hours',
-    'ding-:popular' => 'ding-:popular',
-    'ding-:interaction_pane' => 'ding-:interaction_pane',
-    'ding-:serendipity_ting_object' => 'ding-:serendipity_ting_object',
-    'menus:menu_block-3' => 'menus:menu_block-3',
-    'menus:menu_block-4' => 'menus:menu_block-4',
-    'easyopac:section_description_image' => 'easyopac:section_description_image',
-    'ding-:campaign' => 'ding-:campaign',
-    'ting:carousel' => 'ting:carousel',
+    'ding_nodelist' => 'ding_nodelist',
+    'ding_item_list' => 'ding_item_list',
+    'campaign' => 'campaign',
+    'single_campaign' => 'single_campaign',
+    'carousel' => 'carousel',
+    'ding_event_calendar-ding-event-calendar' => 'ding_event_calendar-ding-event-calendar',
+    'all_opening_hours' => 'all_opening_hours',
+    'popular' => 'popular',
+    'interaction_pane' => 'interaction_pane',
+    'serendipity_ting_object' => 'serendipity_ting_object',
+    'menu_block-3' => 'menu_block-3',
+    'menu_block-4' => 'menu_block-4',
+    'section_description_image' => 'section_description_image',
   );
 
   $selected = variable_get('ding_ipe_filter_panes_selected', $default);

--- a/modules/ding_ipe_filter/includes/ding_ipe_filter.admin.inc
+++ b/modules/ding_ipe_filter/includes/ding_ipe_filter.admin.inc
@@ -45,7 +45,7 @@ function ding_ipe_filter_admin_panes_form($form, $form_state) {
   $options = array();
   foreach ($categories as $key => $category) {
     foreach ($category['content'] as $content) {
-      $options[$key . ':' . $content['subtype_name']] = array(
+      $options[$content['subtype_name']] = array(
         'category' => $category['title'],
         'type' => $content['subtype_name'],
         'title' => $content['title'],


### PR DESCRIPTION

#### Link to issue
https://inlead.atlassian.net/browse/EASYOPAC-1071

#### Description
When you are localadmin and located on https://www.katak.gl/da.
Then you can open IPE and see that "Ting Search Carousel" is not visible.

But if you change language to KL or EN, then its visible:
https://www.katak.gl/kl
https://www.katak.gl/en

IPE does not considers multiple languages. 

#### Screenshot of the result
![Screenshot 2019-04-24 14:23:08](https://user-images.githubusercontent.com/3027336/56655881-a626c200-669c-11e9-87b8-7e1fb16d1b93.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
