### PR TITLE
EASYOPAC-1081 - Default allow multiple news and event title images.

### DIFF
--- a/modules/ding_event/ding_event.features.field_base.inc
+++ b/modules/ding_event/ding_event.features.field_base.inc
@@ -462,7 +462,7 @@ function ding_event_field_default_field_bases() {
   // Exported field_base: 'field_ding_event_title_image'.
   $field_bases['field_ding_event_title_image'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_ding_event_title_image',

--- a/modules/ding_news/ding_news.features.field_base.inc
+++ b/modules/ding_news/ding_news.features.field_base.inc
@@ -248,7 +248,7 @@ function ding_news_field_default_field_bases() {
   // Exported field_base: 'field_ding_news_title_image'.
   $field_bases['field_ding_news_title_image'] = array(
     'active' => 1,
-    'cardinality' => 1,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_ding_news_title_image',


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1081

#### Description

Changed the cardinality of the `title_image` field on `ding_news` and `ding_event` to support multiple images.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This has previously been located in easySuite/ding_nis but has now been moved here (to Core).
