### PR TITLE
NO-TASK - Issue with field module in 4.7.0+easy.

### DIFF
--- a/modules/p2/ding_entity_rating/ding_entity_rating.install
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.install
@@ -11,3 +11,11 @@
 function ding_entity_rating_update_7001() {
   variable_del('ding_entity_rating_popular_on_frontpage');
 }
+
+/**
+ * Remove "ding_entity_rating_result" field from database.
+ */
+function ding_entity_rating_update_7002() {
+  field_delete_field('ding_entity_rating_result');
+  field_purge_batch(1);
+}


### PR DESCRIPTION
#### Description

In https://github.com/ding2/ding2/pull/1421 was removed "ding_entity_rating_result" field from features, but wasn't provided functionality to cleanup this field from database, which in a final was generating notices on updated clients.

#### Checklist

- [X] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
