### PR TITLE
EASYOPAC-1091 - Section-module term variant problem.

### DIFF
--- a/modules/ding_sections/ding_sections.module
+++ b/modules/ding_sections/ding_sections.module
@@ -200,6 +200,7 @@ function ding_sections_secure_permissions($role) {
       'edit any section content',
       'edit own section content',
       'view section panels terms',
+      'use section panels terms',
     ),
     'local editor' => array(
       'view section panels terms',

--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
@@ -397,7 +397,7 @@ function ding_sections_term_panel_create_term_variant($term) {
   $variant_title = t('Sections term (@term)', array('@term' => $term->name));
   $pipeline = module_exists('panels_ipe') ? 'ipe' : 'standard';
 
-  $handler = ding_sections_term_panel_get_handler();
+  $handler = page_manager_load_task_handler('term_view', '', 'term_section_panel_context');
   $handler->name = $handler_name;
   $handler->did = NULL;
   $handler->conf['title'] = $variant_title;


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1091

#### Description

New sections must listen to default panel variant which is stored in database and not the one from code.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.