### PR TITLE
EASYOPAC-1089 - Persist og menu links patch.

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -307,6 +307,7 @@ projects[og][patch][] = "https://www.drupal.org/files/membership-data-loss-user-
 
 projects[og_menu][subdir] = "contrib"
 projects[og_menu][version] = "3.0"
+projects[og_menu][patch][] = "http://storage.easyting.dk/og_menu-make_links_persistent.patch"
 
 projects[opening_hours][subdir] = "contrib"
 projects[opening_hours][version] = "1.6"


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1089

#### Description

Mark OG menu links as `customized` so they persist after cache clear. This is a workaround, no root reason for this bug was found yet.

#### Screenshot of the result

None.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Void.
