### PR TITLE
EASYOPAC-1101 - Culture: Grid campaign not listening to weight.

### DIFF
--- a/modules/ding_campaign/ding_campaign.module
+++ b/modules/ding_campaign/ding_campaign.module
@@ -244,7 +244,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
         AND n.status = 1
         AND r.cid = d.cid
         AND r.cid = n.nid
-      ORDER BY d.weight DESC', array(':nid' => (int) $nid))
+      ORDER BY d.weight ASC', array(':nid' => (int) $nid))
       ->fetchAll();
 
     foreach ($result as $key => $value) {
@@ -263,7 +263,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
         AND n.status = 1
         AND r.cid = d.cid
         AND r.cid = n.nid
-      ORDER BY d.weight DESC', array(':nid' => (int) $nid))
+      ORDER BY d.weight ASC', array(':nid' => (int) $nid))
       ->fetchAll();
 
     foreach ($result as $key => $value) {
@@ -282,7 +282,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
         AND n.status = 1
         AND r.cid = d.cid
         AND r.cid = n.nid
-      ORDER BY d.weight DESC', array(':nid' => (int) $nid))
+      ORDER BY d.weight ASC', array(':nid' => (int) $nid))
       ->fetchAll();
 
     foreach ($result as $key => $value) {
@@ -291,13 +291,13 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
   }
 
   // Process path-based campaigns.
-  $result = db_query('SELECT r.cid, r.rule
+  $result = db_query('SELECT r.cid, r.rule, d.weight
     FROM {ding_campaign_rules} r, {ding_campaign} d, {node} n
     WHERE r.type = \'rule_path\'
       AND n.status = 1
       AND r.cid = d.cid
       AND r.cid = n.nid
-    ORDER BY d.weight DESC')
+    ORDER BY d.weight ASC')
     ->fetchAll();
 
   $path = drupal_get_path_alias($_GET['q']);
@@ -343,7 +343,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
         AND r.cid = d.cid
         AND r.cid = n.nid
         AND r.rule ' . $condition . '
-      ORDER BY d.weight DESC')
+      ORDER BY d.weight ASC')
       ->fetchAll();
 
     foreach ($result as $key => $value) {
@@ -362,7 +362,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
         AND n.status = 1
         AND r.cid = d.cid
         AND r.cid = n.nid
-      ORDER BY d.weight DESC', array(':nid' => (int) $nid))
+      ORDER BY d.weight ASC', array(':nid' => (int) $nid))
       ->fetchAll();
 
     foreach ($result as $key => $value) {
@@ -381,7 +381,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
         AND n.status = 1
         AND r.cid = d.cid
         AND r.cid = n.nid
-      ORDER BY d.weight DESC', array(':tid' => (int) $tid))
+      ORDER BY d.weight ASC', array(':tid' => (int) $tid))
       ->fetchAll();
 
     foreach ($result as $key => $value) {
@@ -396,7 +396,7 @@ function ding_campaign_get_campaigns($context, $limit, $offset) {
       AND n.status = 1
       AND r.cid = d.cid
       AND r.cid = n.nid
-    ORDER BY d.weight DESC')
+    ORDER BY d.weight ASC')
     ->fetchAll();
 
   foreach ($result as $key => $value) {


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1101

#### Description
 
Changed the order of SQL query results because 'DESC' order was pushing negative weight into the end of results array, what is disagreeing with default Drupal weighting functionality when negative values have higher weight than positives one.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.