### PR TITLE
EASYOPAC-977 - Remove quick reservation functionality.

### DIFF
--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -193,17 +193,7 @@ function ding_reservation_reserve_ajax($entity, $reservable = NULL) {
       // the options to select branch and period.
       $defaults = ding_provider_invoke('reservation', 'default_options', $user);
       $matches = preg_grep("/preferred_branch$/", array_keys($defaults));
-      $profile = ding_user_provider_profile($user);
-      // @todo This should be moved to separate module.
-      $user_quick_reservation = $profile->field_quick_reservation[LANGUAGE_NONE][0]['value'];
-      $admin_quick_reservation = variable_get('ding_quick_reservation');
-      if ($admin_quick_reservation == "0") {
-        $quick_reservation = ($user_quick_reservation == "0") ? TRUE : FALSE;
-      }
-      else {
-        $quick_reservation = ($user_quick_reservation == "0") ? FALSE : TRUE;
-      }
-      if (empty($defaults[array_shift($matches)]) || $quick_reservation) {
+      if (empty($defaults[array_shift($matches)])) {
         $form = ding_provider_get_form('ding_reservation_reserve_form', $reservable, FALSE);
         $commands[] = ajax_command_ding_popup('ding_reservation', t('Reservation'), render($form));
       }


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-977

#### Description

Functionality moved to https://github.com/easySuite/ding_reservation_settings/pull/6.

No other method could find other then alter hook menu.
Tried to inject into the hook_provider_invoke, but this solution requires definition of another provider with all its related hooks. Also, tried inject into the hook_ding_entity_button to alter the reservation link, but the result does not differ from this one. Tried to inject into the ding_reservation_reserve_form but the solution is more hacky than this.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
