### PR TITLE
NO-TASK - Event list filtering fix.

### DIFF
--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -241,10 +241,11 @@ function ding_event_views_pre_execute(&$view) {
         ->conditions()[0]['field']
         ->conditions()[0]['field']
         ->conditions()[4];
+
+      $date_condition['field'] .= ' OR (fdelf.field_ding_event_list_filter_value = :filter'
+        . ' AND ' . str_replace('.field_ding_event_date_value,', '.field_ding_event_date_value2,', $date_condition['field']) . ')';
+      $date_condition['value'][':filter'] = 'show_all';
     }
-    $date_condition['field'] .= ' OR (fdelf.field_ding_event_list_filter_value = :filter'
-                              . ' AND ' . str_replace('.field_ding_event_date_value,', '.field_ding_event_date_value2,', $date_condition['field']) . ')';
-    $date_condition['value'][':filter'] = 'show_all';
   }
 }
 


### PR DESCRIPTION
#### Link to issue

PROD issue.

#### Description

In case when Event list page filters are empty, the additional conditions added in code to views query were added in the wrong place, so it was trying to add code into filter which was an instance of SelectQuery class.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.