### PR TITLE
HOTFIX - Translate 'More link' for nodelist panes.

### DIFF
--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1885,7 +1885,7 @@ function ding_nodelist_preprocess(&$variables, $hook) {
 
       $links = array();
       foreach ($variables['links'] as $link) {
-        $links[] = l(t('@text', array('@text' => $link['text'])), $link['links']);
+        $links[] = l(t($link['text']), $link['links']);
       }
       $variables['links'] = $links;
       $variables['items'] = $items;


### PR DESCRIPTION
#### Description

Wrong mechanism for translating "More link" labels for nodelists was chosen. This PR fixes this issue and the label as a string will be available in translation interface instead of token.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.