### PR TITLE
EASYOPAC-1142 - Hide OH on Library if empty checked.

### DIFF
--- a/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/plugins/content_types/weekly_opening_hours.inc
+++ b/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/plugins/content_types/weekly_opening_hours.inc
@@ -29,6 +29,10 @@ function ding_ddbasic_opening_hours_weekly_opening_hours_content_type_render($su
     $node = node_load($conf['node']);
   }
 
+  if (empty(opening_hours_present_on_node($node->nid)) && variable_get('opening_hours_hide_on_empty_ding_library', 0) == 1) {
+    return $block;
+  }
+
   if (empty($node)) {
     return $block;
   }


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1142

#### Description

In ding_library content type settings we have config option "Hide opening hours if not one wasn't added." which is responsible of hiding or displaying OH block/pane on libraries pages.
There was an issue that this option didn't had any effect - this commit fixes this issue.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.