### PR TITLE
EASYOPAC-NO_TASK

### DIFF
--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -603,7 +603,7 @@ function ding_base_file_presave($file) {
         case IMAGETYPE_PNG:
           $image = imagecreatefrompng($file->destination);
           imagedestroy(imagecreatefrompng($file->destination));
-          imagepng($image, $file->destination, 100);
+          imagepng($image, $file->destination, 7);
           break;
         default:
           break;


### PR DESCRIPTION
EASYOPAC-NO_TASK - Proper quality setting when saving png images.

#### Link to issue

None. Hotfix.

#### Description

Images that are png files are faulty saved. The reason behind this is wrong `imagepng` third arguments value, which can onle be compression value within 0-9.

#### Screenshot of the result

None.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

None.
