### PR TITLE
EASYOPAC-1195 - Build and enable ting_recommender module.

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -47,6 +47,7 @@ dependencies[] = ding_ddbasic_opening_hours
 dependencies[] = ding_social_links
 dependencies[] = ding_sections
 dependencies[] = ding_nodelist
+dependencies[] = ting_recommender
 
 ; Cache/performance modules
 dependencies[] = entitycache

--- a/ding2.install
+++ b/ding2.install
@@ -836,3 +836,10 @@ function ding2_update_7072() {
 function ding2_update_7073() {
   ding2_translation_update();
 }
+
+/**
+ * Enable Ting Recommender.
+ */
+function ding2_update_7074() {
+  module_enable(['ting_recommender']);
+}

--- a/easyopac.make
+++ b/easyopac.make
@@ -432,6 +432,13 @@ projects[ting_proposed_searches][download][url]    = "git@github.com:easySuite/t
 ;projects[ting_proposed_searches][download][tag]    = ""
 projects[ting_proposed_searches][download][branch] = "development"
 
+projects[ting_recommender][type]              = "module"
+projects[ting_recommender][subdir]            = ""
+projects[ting_recommender][download][type]    = "git"
+projects[ting_recommender][download][url]     = "git@github.com:easySuite/ting_recommender.git"
+;projects[ting_recommender][download][tag]     = ""
+projects[ting_recommender][download][branch]  = "development"
+
 projects[ting_reference_advanced][type]              = "module"
 projects[ting_reference_advanced][subdir]            = ""
 projects[ting_reference_advanced][download][type]    = "git"


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1195

#### Description

Added ting_recommender module in easyopac.make file and enable this on site installation or updates execution.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.