### PR TITLE
EASYOPAC-1171 - Tags autocomplete filter on editorial search.

### DIFF
--- a/modules/ding_frontend/ding_frontend.module
+++ b/modules/ding_frontend/ding_frontend.module
@@ -62,6 +62,13 @@ function ding_frontend_menu() {
     'type' => MENU_NORMAL_ITEM,
   );
 
+  $items['ding_frontend/autocomplete'] = [
+    'title' => 'Autocomplete taxonomy',
+    'page callback' => 'ding_frontend_taxonomy_autocomplete',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  ];
+
   return $items;
 }
 
@@ -278,6 +285,25 @@ function ding_frontend_search_api_views_query_alter(view &$view, SearchApiViewsQ
 }
 
 /**
+ * Implements hook_search_api_query_alter().
+ */
+function ding_frontend_search_api_query_alter(SearchApiQueryInterface $query) {
+  if (isset($_GET['tags_filter']) && !empty($_GET['tags_filter'])) {
+    $tag = $_GET['tags_filter'];
+
+    $term = taxonomy_get_term_by_name($tag, 'ding_content_tags');
+    if (!empty($term)) {
+      $term = reset($term);
+      $subfilter = $query->createFilter('OR');
+      $subfilter->condition('node:field_ding_event_tags', $term->tid, '=');
+      $subfilter->condition('node:field_ding_news_tags', $term->tid, '=');
+      $subfilter->condition('node:field_ding_page_tags', $term->tid, '=');
+      $query->filter($subfilter);
+    }
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function ding_frontend_form_alter(&$form, &$form_state, $form_id) {
@@ -293,6 +319,30 @@ function ding_frontend_form_alter(&$form, &$form_state, $form_id) {
 
     $form['ct']['#options'] = $cleared;
     $form['ct']['#default_value'] = [];
+
+    // Add "Tags" filter.
+    $form['#info']['tags_filter'] = [
+      'value' => 'tags_filter',
+      'label' => 'Tags',
+      'weight' => -11,
+    ];
+
+    $form['tags_filter'] = [
+      '#type' => 'textfield',
+      '#autocomplete_path' => 'ding_frontend/autocomplete',
+      '#id' => 'custom-tags-filter',
+      '#attributes' => [
+        'class' => [
+          'ctools-auto-submit-exclude',
+        ],
+        'placeholder' => t('Filter by tags'),
+      ],
+      '#attached' => [
+        'js' => [
+          drupal_get_path('module', 'ding_frontend') . '/js/ding_frontend.js',
+        ]
+      ]
+    ];
   }
 }
 
@@ -302,7 +352,7 @@ function ding_frontend_form_alter(&$form, &$form_state, $form_id) {
 function ding_frontend_preprocess_views_exposed_form(&$variables) {
   if ($variables['form']['#id'] == 'views-exposed-form-ding-multiple-search-panel-pane-1') {
     $form = $variables['form'];
-    $excluded_widgets = ['node_field_ding_page_tags', 'node_field_ding_event_tags', 'node_field_ding_news_tags'];
+    $excluded_widgets = ['tags_filter'];
     foreach ($form['#info'] as $widget => $item) {
       if (!in_array($item['value'], $excluded_widgets)) {
         $items = [];
@@ -332,4 +382,24 @@ function ding_frontend_preprocess_views_exposed_form(&$variables) {
       }
     }
   }
+}
+
+/**
+ * Editorial search "tags" filter autocomplete callback.
+ */
+function ding_frontend_taxonomy_autocomplete($tag) {
+    $vid = taxonomy_vocabulary_machine_name_load('ding_content_tags');
+    $tags = db_select('taxonomy_term_data', 't')
+      ->fields('t', ['tid', 'name'])
+      ->condition('vid', $vid->vid)
+      ->condition('t.name', '%' . db_like($tag) . '%', 'LIKE')
+      ->execute()
+      ->fetchAll();
+
+    $items = [];
+    foreach ($tags as $item) {
+      $items[$item->name] = $item->name;
+    }
+
+    drupal_json_output($items);
 }

--- a/modules/ding_frontend/js/ding_frontend.js
+++ b/modules/ding_frontend/js/ding_frontend.js
@@ -1,0 +1,13 @@
+(function ($) {
+  'use strict';
+
+  Drupal.behaviors.ding_frontend = {
+    attach: function (context) {
+      // Submit tags filter only after element is selected.
+      let tags_filter_input = $('#custom-tags-filter', context);
+      tags_filter_input.on('blur', function () {
+        $('form#views-exposed-form-ding-multiple-search-panel-pane-1 input[type=submit]').click();
+      });
+    }
+  };
+})(jQuery);

--- a/modules/ding_frontend/templates/ding-frontpage--views-exposed-form-widget.tpl.php
+++ b/modules/ding_frontend/templates/ding-frontpage--views-exposed-form-widget.tpl.php
@@ -3,6 +3,9 @@
 /**
  * @file
  * Views Exposed Form Widget template.
+ * @var array $variables
+ * @var array $element
+ * @var string $title
  */
 
 $element_name = $element['#name'] . '[]';
@@ -11,12 +14,16 @@ $element_id = $element['#id'];
 
 <div class="views-exposed-form-widget" id="<?php print $element_id; ?>">
   <h2 class="sub-menu-title"><?php print $title; ?></h2>
-  <ul class="sub-menu">
-    <?php foreach ($items as $key => $item): ?>
-      <li>
-        <input type="checkbox" id="<?php print $element_id . '-' . $key; ?>" name="<?php print $element_name; ?>" value="<?php print $key; ?>">
-        <label for="<?php print $element_id . '-' . $key; ?>" class="menu-item"><?php print $item; ?></label>
-      </li>
-    <?php endforeach; ?>
-  </ul>
+  <?php if ($element['#type'] != 'textfield') : ?>
+    <ul class="sub-menu">
+      <?php foreach ($items as $key => $item): ?>
+        <li>
+          <input type="checkbox" id="<?php print $element_id . '-' . $key; ?>" name="<?php print $element_name; ?>" value="<?php print $key; ?>">
+          <label for="<?php print $element_id . '-' . $key; ?>" class="menu-item"><?php print $item; ?></label>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php else: ?>
+    <?php print render($element); ?>
+  <?php endif; ?>
 </div>


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1171

#### Description

Added autocomplete tag filter functionality for Editorial Content search.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.