### PR TITLE
EASYOPAC-1201 - Cover images should be smaller in all carousels.

### DIFF
--- a/themes/ddbasic/sass/components/ding-carousel.scss
+++ b/themes/ddbasic/sass/components/ding-carousel.scss
@@ -94,8 +94,8 @@
   .slick-slider {
     position: relative;
     clear: left;
-    min-height: 418px; // Prevent page from jumping when content is loaded in
-    max-height: 418px;
+    min-height: 318px; // Prevent page from jumping when content is loaded in
+    max-height: 318px;
 
     //If ting-object-no-overlay
     @at-root .ting-object-no-overlay#{&} {
@@ -110,7 +110,7 @@
     }
 
     .slick-list {
-      max-height: 418px;
+      max-height: 332px;
 
       //If ting-object-no-overlay
       @at-root .ting-object-no-overlay#{&} {
@@ -124,7 +124,7 @@
 
     .slick-track {
       .slick-slide {
-        width: 260px;
+        width: 194px;
         margin-right: 28px;
         text-align: left;
         margin-bottom: 0;
@@ -134,7 +134,7 @@
         }
 
         img {
-          height: 380px !important;
+          height: 284px !important;
           display: block;
         }
 
@@ -153,7 +153,7 @@
 
       .placeholder {
         @include linear-gradient(to top, $grey-light 30px, $grey-medium 100%);
-        min-height: 336px;
+        min-height: 266px;
 
         .icon-spinner {
           position: relative;

--- a/themes/ddbasic/sass/components/field.scss
+++ b/themes/ddbasic/sass/components/field.scss
@@ -307,7 +307,7 @@ div.search-field-in-content--message {
 .ting-reference-item {
   .placeholder {
     @include linear-gradient(to top, $grey-light 30px, $grey-medium 100%);
-    min-height: 336px;
+    min-height: 266px;
 
     .icon-spinner {
       position: relative;


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1201

#### Description

Changing sizing of carousels elements in order to have 5 items in carousel and save some useful space on frontend UI.

#### Screenshot of the result

![1576671826627](https://user-images.githubusercontent.com/800338/71086545-e8a88c00-21a2-11ea-816e-3e41cc507cce.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.