### PR TITLE
EASYOPAC-1211 - Add 'pending' option in availability legend.

### DIFF
--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -392,6 +392,7 @@ function ding_availability_render_legend() {
   $availability_legend['on-loan'] = t('On loan');
   $availability_legend['unavailable'] = t('Unavailable');
   $availability_legend['unreservable'] = t('Not reservable');
+  $availability_legend['pending'] = t('Status inaccessible');
 
   // Render image html using theme_image (returns NULL if file doesn't exist).
   foreach ($availability_legend as $key => $val) {


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1211

#### Description

There is a 'easyddb_legend' module which is highlighting material type labels in predefined colors according to availability info received and render the legend of those colors. In this commit is added  status "Status inaccessible" which is assigned to the items which are in pending state or info is not accessible for this item.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/800338/72731694-dd2ef300-3b9c-11ea-9732-6ce5c9281787.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
