### PR TITLE
NO-TASK - Nodelist Promoted node items are linking to wrong nodes.

### DIFF
--- a/themes/ddbasic/scripts/ddbasic.common.js
+++ b/themes/ddbasic/scripts/ddbasic.common.js
@@ -230,22 +230,27 @@
   // Nodelist "Promoted Nodes".
   Drupal.behaviors.ding_nodelist_promoted_nodes = {
     attach: function (context, settings) {
-      // "Promoted nodes" items classes list.
-      var classes = ['first-left-block', 'first-right-block', 'last-left-block', 'last-right-block'];
-      classes.forEach(function (value) {
-        // Getting item wrapper.
-        var itemWrapper = $('.' + value);
-        // Extracting item's url from wrapper.
-        var href = itemWrapper.data('href');
-        itemWrapper.on('mouseover click', function (event) {
-          // Always display pointer cursor.
-          itemWrapper.css('cursor', 'pointer');
-          // Act as a click on link when "click" event is executed.
-          if (event.type === 'click') {
-            window.location.href = href;
-          }
+      var pnNodelistPanes = $('.pane-ding-nodelist .ding_nodelist', context);
+      if (pnNodelistPanes.length > 0) {
+        $(pnNodelistPanes).each(function (i, block) {
+          // "Promoted nodes" items classes list.
+          var classes = ['first-left-block', 'first-right-block', 'last-left-block', 'last-right-block'];
+          classes.forEach(function (value) {
+            // Getting item wrapper.
+            var itemWrapper = $('.' + value, block);
+            // Extracting item's url from wrapper.
+            var href = itemWrapper.data('href');
+            itemWrapper.on('mouseover click', function (event) {
+              // Always display pointer cursor.
+              itemWrapper.css('cursor', 'pointer');
+              // Act as a click on link when "click" event is executed.
+              if (event.type === 'click') {
+                window.location.href = href;
+              }
+            });
+          });
         });
-      });
+      }
     }
   };
 


### PR DESCRIPTION
#### Description

When we have more than 1 panel pane of type ding_nodelist with selected "Promoted nodes" widget on one page, items from the rest of "Promoted nodes" nodelists are linking to the items from the first one.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.