### PR TITLE
NO-TASK - Add paragraphs and paragraphs text field to search index.

### DIFF
--- a/modules/ding_frontend/ding_frontend.features.inc
+++ b/modules/ding_frontend/ding_frontend.features.inc
@@ -576,9 +576,13 @@ function ding_frontend_default_search_api_index() {
         "node:field_ding_library_phone_number" : { "type" : "text" },
         "node:field_ding_news_category" : { "type" : "integer", "entity_type" : "taxonomy_term" },
         "node:field_ding_news_lead" : { "type" : "text" },
+        "node:field_ding_news_paragraphs" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "paragraphs_item" },
+        "node:field_ding_news_paragraphs:field_ding_paragraphs_box_text:value" : { "type" : "list\\u003Ctext\\u003E" },
+        "node:field_ding_news_paragraphs:field_ding_paragraphs_text:value" : { "type" : "list\\u003Ctext\\u003E" },
         "node:field_ding_news_tags" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "node:field_ding_page_lead" : { "type" : "text" },
         "node:field_ding_page_paragraphs" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "paragraphs_item" },
+        "node:field_ding_page_paragraphs:field_ding_paragraphs_box_text:value" : { "type" : "list\\u003Ctext\\u003E" },
         "node:field_ding_page_paragraphs:field_ding_paragraphs_text:value" : { "type" : "list\\u003Ctext\\u003E" },
         "node:field_ding_page_tags" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "node:nid" : { "type" : "integer" },
@@ -1372,6 +1376,27 @@ function ding_frontend_default_search_api_server() {
             "boost" : "1.0"
           },
           "node:field_ding_page_paragraphs:field_ding_paragraphs_text:value" : {
+            "table" : "search_api_db_default_multiple_index_text",
+            "type" : "list\\u003Ctext\\u003E",
+            "boost" : "1.0"
+          },
+          "node:field_ding_news_paragraphs" : {
+            "table" : "search_api_db_default_multiple_index_node_field_ding_news_para",
+            "column" : "value",
+            "type" : "list\\u003Cinteger\\u003E",
+            "boost" : "1.0"
+          },
+          "node:field_ding_news_paragraphs:field_ding_paragraphs_text:value" : {
+            "table" : "search_api_db_default_multiple_index_text",
+            "type" : "list\\u003Ctext\\u003E",
+            "boost" : "1.0"
+          },
+          "node:field_ding_news_paragraphs:field_ding_paragraphs_box_text:value" : {
+            "table" : "search_api_db_default_multiple_index_text",
+            "type" : "list\\u003Ctext\\u003E",
+            "boost" : "1.0"
+          },
+          "node:field_ding_page_paragraphs:field_ding_paragraphs_box_text:value" : {
             "table" : "search_api_db_default_multiple_index_text",
             "type" : "list\\u003Ctext\\u003E",
             "boost" : "1.0"

--- a/modules/ding_frontend/ding_frontend.features.inc
+++ b/modules/ding_frontend/ding_frontend.features.inc
@@ -578,6 +578,8 @@ function ding_frontend_default_search_api_index() {
         "node:field_ding_news_lead" : { "type" : "text" },
         "node:field_ding_news_tags" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "node:field_ding_page_lead" : { "type" : "text" },
+        "node:field_ding_page_paragraphs" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "paragraphs_item" },
+        "node:field_ding_page_paragraphs:field_ding_paragraphs_text:value" : { "type" : "list\\u003Ctext\\u003E" },
         "node:field_ding_page_tags" : { "type" : "list\\u003Cinteger\\u003E", "entity_type" : "taxonomy_term" },
         "node:nid" : { "type" : "integer" },
         "node:title" : { "type" : "text", "boost" : "2.0" },
@@ -1361,6 +1363,17 @@ function ding_frontend_default_search_api_server() {
           "user:profile_ding_staff_profile:field_ding_staff_work_areas" : {
             "table" : "search_api_db_default_multiple_index_text",
             "type" : "text",
+            "boost" : "1.0"
+          },
+          "node:field_ding_page_paragraphs" : {
+            "table" : "search_api_db_default_multiple_index_node_field_ding_page_para",
+            "column" : "value",
+            "type" : "list\\u003Cinteger\\u003E",
+            "boost" : "1.0"
+          },
+          "node:field_ding_page_paragraphs:field_ding_paragraphs_text:value" : {
+            "table" : "search_api_db_default_multiple_index_text",
+            "type" : "list\\u003Ctext\\u003E",
             "boost" : "1.0"
           }
         }


### PR DESCRIPTION
#### Description

Ding page CT's body field was changed to use paragraphs functionality. Paragraphs entity have it's own fields which wasn't added to Search API index used for nodes search.
In this PR is added paragraphs text field to search index.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Ensure `default_multiple_index` (@/admin/config/search/search_api/index/default_multiple_index) index is re-indexed after changes deploy.
