### PR TITLE
NO_TASK - Consider special characters on tring truncation.

### DIFF
--- a/themes/ddbasic/utils.inc
+++ b/themes/ddbasic/utils.inc
@@ -128,12 +128,14 @@ function ddbasic_account_count_reservation_not_ready($account = NULL) {
 }
 
 /**
- * Function to truncate strings
+ * Function to truncate strings.
+ *
+ * Consider special danish characters on string length calculation and truncate.
  */
 function add_ellipsis($string, $length = 200, $end = '...') {
   if (strlen($string) > $length) {
-    $length -= strlen($end);
-    $string  = substr($string, 0, $length);
+    $length -= mb_strlen($end);
+    $string  = mb_substr($string, 0, $length);
     $string .= '<span class="truncation">' . $end . '</span>';
   }
 


### PR DESCRIPTION
#### Description

Ting search carousels could not be saved in the IPE view. The problem occurs when the title or description of the ting object is truncated in the "middle" special character. E.g. æ in the word Kælderbiblioteket. 

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
