### PR TITLE
SUP-1805 - Sticky header in profile lists is on top of list.

### DIFF
--- a/themes/ddbasic/scripts/account.js
+++ b/themes/ddbasic/scripts/account.js
@@ -9,9 +9,12 @@
       offset,
       is_mobile;
 
+    $(document).ready(function () {
+      offset = $('.js-content-wrapper').offset().top;
+    })
+
     $(window)
       .bind('resize.actions_container', function (evt) {
-        offset = $('.js-content-wrapper').offset().top;
         is_mobile = ddbasic.breakpoint.is('mobile');
 
         // Set the width of the container, so it matches the form.
@@ -45,6 +48,11 @@
           return;
         }
 
+        $(this).on('resize', function () {
+          offset = $('.js-content-wrapper').offset().top;
+          $('.js-content-wrapper').offset().top = offset;
+        });
+
         // The mark where the container starts sticking.
         var mark = $(window).scrollTop() + offset;
 
@@ -67,6 +75,7 @@
             // Stick it to the top.
             else {
               if (!container.hasClass('is-fixed')) {
+                offset = $('.js-content-wrapper').offset().top;
                 container
                   .addClass('is-fixed')
                   .removeClass('is-bottom')


### PR DESCRIPTION
#### Description

In user profile's lists (loan/debts/reservation) overall table heading must be sticky, but it's not, on page scroll it is not visible because it's hidden under search form.

#### Screenshot of the result

![faxbib_lists](https://user-images.githubusercontent.com/800338/78883148-c09aac80-7a61-11ea-85ef-65bdec0c357b.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.