### PR TITLE
SUP-1879 - Possibility to translate titel of search profiles.

### DIFF
--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -492,10 +492,18 @@ function ting_field_search_filter_profiles() {
   foreach (ting_field_search_profiles_sort($profiles) as $name => $profile) {
     // Only exposed and activated profiles should be shown to the user.
     if ($profile->config['user_interaction']['exposed'] && empty($profile->disabled)) {
+
+      if (module_exists('ding_language')) {
+        $profile_title = i18n_string('ting_field_search:' . $profile->name, check_plain($profile->title), ['update' => TRUE]);
+      }
+      else {
+        $profile_title = $profile->title;
+      }
+
       // Filter based on grouping (always show profiles from same group).
       if ($active_profile && $active_profile->config['user_interaction']['grouping'] == $profile->config['user_interaction']['grouping']) {
         $exposed_profiles[$name] = t('Search in @profile', array(
-          '@profile'  => check_plain($profile->title),
+          '@profile'  => $profile_title,
         ));
         continue;
       }
@@ -510,7 +518,7 @@ function ting_field_search_filter_profiles() {
       if ($profile->config['user_interaction']['visibility'] !== 'all' &&
         ting_field_search_profile_matches_current_path($profile)) {
           $exposed_profiles[$name] = t('Search in @profile', array(
-            '@profile'  => check_plain($profile->title),
+            '@profile'  => $profile_title,
           ));
           continue;
       }
@@ -519,13 +527,28 @@ function ting_field_search_filter_profiles() {
       // pages.
       if (!$active_profile && $profile->config['user_interaction']['visibility'] == 'all') {
         $exposed_profiles[$name] = t('Search in @profile', array(
-          '@profile'  => check_plain($profile->title),
+          '@profile'  => $profile_title,
         ));
       }
     }
   }
 
   return $exposed_profiles;
+}
+
+/**
+ * Implements hook_i18n_string_info().
+ */
+function ting_field_search_i18n_string_info() {
+  if (module_exists('ding_language')) {
+    $groups['ting_field_search'] = [
+      'title' => t('Ting Field Search'),
+      'format' => FALSE,
+      'list' => TRUE,
+    ];
+
+    return $groups;
+  }
 }
 
 /**


### PR DESCRIPTION
#### Description

Adding functionality for making possible to translate title of search profiles.

After delivering code:
1. Clear cache
2. Visit any page where is present search form with search profiles
3. Go to `/admin/config/regional/translate/translate` page, from `Limit search to`  filter select list choose **Ting Field Search**, after that you'll see in table below all Ting Search Profile titles with the possibility to translate them.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I've tried to move this out of the core, but this is not possible in this case.