### PR TITLE
EASYOAPC-1224 - Set title configs on ting search carousel.

### DIFF
--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -165,6 +165,11 @@ function ting_search_carousel_carousel_content_type_edit_form_submit(&$form, &$f
       $searches[] = $search;
     }
   }
+
+  $form_state['conf']['override_title'] = $form_state['input']['override_title'];
+  $form_state['conf']['override_title_text'] = $form_state['input']['override_title_text'];
+  $form_state['conf']['override_title_heading'] = $form_state['input']['override_title_heading'];
+
   $form_state['conf']['searches'] = $searches;
   $form_state['conf']['settings'] = $form_state['values']['settings'];
   // Pre-request first set of results so the caching will be done while form


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1224

#### Description

Title of the ting search carouse pane is not added on first pane insert.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/3027336/81536588-7e240280-9374-11ea-9047-c9028a714fa3.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
