### PR TITLE
EASYOAPC-1224 - Add update hook for easyopac layout page.

### DIFF
--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
@@ -136,3 +136,16 @@ function ding_sections_term_panel_update_7001(&$sandbox) {
   $handler = ding_sections_term_panel_get_handler();
   page_manager_save_task_handler($handler);
 }
+
+/**
+ * Use the easyOPAC base layout a base for the sections.
+ */
+function ding_sections_term_panel_update_7002(&$sandbox) {
+  $handler = page_manager_load_task_handler('term_view', '', 'term_section_panel_context');
+  if ($handler) {
+    page_manager_delete_task_handler($handler);
+  }
+
+  $handler = ding_sections_term_panel_get_handler();
+  page_manager_save_task_handler($handler);
+}


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1224

#### Description

Added hook update to use the easyOPAC layout for ding sections.
If the module is already enabled then the changes does not apply. It needs for the base layout to be updated.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
