### PR TITLE
EASYOPAC-1233 - Status display on Event CTs.

### DIFF
--- a/easyopac.make
+++ b/easyopac.make
@@ -348,6 +348,13 @@ projects[easyopac_abstracts_override][download][url]    = "git@github.com:easySu
 ;projects[easyopac_abstracts_override][download][tag]    = ""
 projects[easyopac_abstracts_override][download][branch] = "development"
 
+projects[easyddb_event_status][type]             = "module"
+projects[easyddb_event_status][subdir]           = ""
+projects[easyddb_event_status][download][type]   = "git"
+projects[easyddb_event_status][download][url]    = "git@github.com:easySuite/easyddb_event_status.git"
+;projects[easyddb_event_status][download][tag]    = ""
+projects[easyddb_event_status][download][branch] = "development"
+
 projects[easyopac_facets][type]             = "module"
 projects[easyopac_facets][subdir]           = ""
 projects[easyopac_facets][download][type]   = "git"

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php
@@ -12,7 +12,7 @@ if (!empty($item->image)) {
   $image = '<div class="event-image" style="background-image:url(' . $item->image . ');"></div>';
 }
 ?>
-<div class="item">
+<div class="item"<?php print $attributes; ?>>
   <?php print $image; ?>
   <div class="event-time">
     <div class="event-day"><?php print format_date($item->timestamp, 'custom', 'D', $item->timezone); ?></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.grid_images.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.grid_images.tpl.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<div class="grid-images-event-item nodelist-item">
+<div class="grid-images-event-item nodelist-item"<?php print $attributes; ?>>
     <a href="<?php print url('node/' . $item->nid); ?>">
         <div class="grid-images-item-image background-image-styling-16-9"
              style="background-image: url(<?php print $item->image; ?>)"></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.horizontal_accordion.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.horizontal_accordion.tpl.php
@@ -5,7 +5,7 @@
  * Ding event horizontal accordion template.
  */
 ?>
-<li class="event item">
+<li class="event item"<?php print $attributes; ?>>
   <div class="item_content">
     <div class="expand"><?php print l($item->title, 'node/' . $item->nid);?></div>
     <div class="event-time">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.minimal_display.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.minimal_display.tpl.php
@@ -5,7 +5,7 @@
  * Minimal display event display template.
  */
 ?>
-<table>
+<table<?php print $attributes; ?>>
   <tr class="minimal-item <?php print $class; ?>">
     <td class="minimal-title"><?php print l($item->title, 'node/' . $item->nid); ?></td>
     <td class="minimal-date"><?php print format_date($item->timestamp, 'custom', 'd/m', $item->timezone); ?></td>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.node_blocks.tpl.php
@@ -7,7 +7,7 @@
 ?>
 
 <article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>"
-         class="node node-ding-event node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">
+         class="node node-ding-event node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>"<?php print $attributes; ?>>
   <a href="<?php print '/node/' . $item->nid; ?>">
     <?php if (!empty($item->image)): ?>
       <div class="event-list-image nb-image" style="background-image:url(<?php print $item->image; ?>);"></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.promoted_nodes.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.promoted_nodes.tpl.php
@@ -17,6 +17,7 @@ $classes = implode(" ", $classes);
   <?php if (!empty($item->image) && $position): ?>
     style="background-image: url(<?php print $item->image; ?>);"
   <?php endif; ?>
+  <?php print $attributes; ?>
 >
   <?php if (isset($item->video)): ?>
     <div class="media-container">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php
@@ -5,8 +5,7 @@
  * Ding event slider template.
  */
 ?>
-<li class="item">
-  
+<li class="item"<?php print $attributes; ?>>
   <h3 class="node-title">
       <?php print l($item->title, 'node/' . $item->nid); ?>
   </h3>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.taxonomy.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.taxonomy.tpl.php
@@ -39,7 +39,7 @@
   </span>
   </div>
 <?php endif; ?>
-<div class="item">
+<div class="item"<?php print $attributes; ?>>
   <?php if ($item->image): ?>
     <div class="item-list-image">
       <?php print $item->image_link; ?>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_page.rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_page.rolltab.tpl.php
@@ -20,7 +20,7 @@ if (!empty($body) && substr($body, 0, 2) === '<p') {
 }
 
 ?>
-<div class="ding-tabroll">
+<div class="ding-tabroll"<?php print $attributes; ?>>
   <div class="ui-tabs-panel">
     <div class="image">
       <?php if (!$item->image): ?>


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1233

#### Description

In order to have possibility to pass any attributes to ding_nodelist event templates, was added ```$attributes``` variable which is processed automatically by drupal and renders all attributes passed in preproces functions.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Those changes have to be merged and deployed in order to have module ```easyddb_event_status``` working.
