### PR TITLE
EASYOPAC-NO_TASK - Omit the language prefix from redirect url.

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -131,14 +131,18 @@ function ding_adgangsplatformen_ding_provider_user() {
  * Implements hook_ajax_login_command().
  */
 function ding_adgangsplatformen_ajax_login_command($path) {
+  global $language;
+
   // Javascript needed to do the redirect is loaded in the init hook.
   ctools_include('ajax');
 
   // Get authentication url and set the path to be redirected back to.
   $url = ding_adgangsplatformen_generate_login_url($path);
 
+  $request_path = request_path();
+  $request_path = preg_replace("/^{$language->language}\//", '', $request_path);
   // Store the ajax callback url that triggered the ajax auth redirect.
-  $_SESSION['oauth2ajax'] = request_path() . '?' . drupal_http_build_query(drupal_get_query_parameters());
+  $_SESSION['oauth2ajax'] = $request_path . '?' . drupal_http_build_query(drupal_get_query_parameters());
 
   return ctools_ajax_command_redirect($url);
 }

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -853,13 +853,18 @@ function ding_user_forms($form_id, $args) {
  *   Ajax command array.
  */
 function ajax_command_ding_user_authenticate($extra_data, $redirect_uri = '') {
+  global $language;
+
   $hook = 'ajax_login_command';
   $modules = module_implements($hook);
+
+  $url = parse_url($_SERVER['HTTP_REFERER']);
+  $path_start = strpos($_SERVER['HTTP_REFERER'], '/', drupal_strlen($url['scheme']) + 3);
+  $referer = drupal_substr($_SERVER['HTTP_REFERER'], $path_start + 1);
+  $referer = preg_replace("/^{$language->language}\//", '', $referer);
+
   if (count($modules) > 0) {
     if (empty($redirect_uri)) {
-      $url = parse_url($_SERVER['HTTP_REFERER']);
-      $path_start = strpos($_SERVER['HTTP_REFERER'], '/', drupal_strlen($url['scheme']) + 3);
-      $referer = drupal_substr($_SERVER['HTTP_REFERER'], $path_start + 1);
       $redirect_uri = empty($referer) ? '/' : urldecode($referer);
     }
 
@@ -871,9 +876,6 @@ function ajax_command_ding_user_authenticate($extra_data, $redirect_uri = '') {
     // Change default ajax action to default login form's if https is enabled.
     if (variable_get('https', FALSE)) {
       $form = drupal_get_form('user_login');
-      $url = parse_url($_SERVER['HTTP_REFERER']);
-      $path_start = strpos($_SERVER['HTTP_REFERER'], '/', drupal_strlen($url['scheme']) + 3);
-      $referer = drupal_substr($_SERVER['HTTP_REFERER'], $path_start + 1);
 
       $form['#action'] = 'https://' . $_SERVER['SERVER_NAME'] . url('user/login') . '?destination=' . $referer;
     }


### PR DESCRIPTION
#### Link to issue

None.

#### Description

Removes the language prefix from redirection url's generated during 3rd party logins. If language detection is set to url, the language prefix is prepended to the redirection route and eventually, is fed to `drupal_goto` -> `url` which prepends language prefix again.

#### Screenshot of the result

None.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Can only be tested @ production.
