### PR TITLE
EASYOPAC-1237 - Push event status label and color.

### DIFF
--- a/modules/ding_mobilesearch/ding_mobilesearch.module
+++ b/modules/ding_mobilesearch/ding_mobilesearch.module
@@ -414,30 +414,6 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
           ),
         );
       }
-
-      // TODO: Separate method to fill in the mapping.
-      $field_name = 'field_ding_event_status_label';
-      $items = field_get_items('node', $node, $field_name);
-      if (is_array($items) && !empty($items)) {
-        $item = reset($items);
-        $mapping['fields'][$field_name] = [
-          'name' => 'Event status label',
-          'value' => $item['value'],
-          'attr' => [],
-        ];
-      }
-
-      $field_name = 'field_ding_event_status_color';
-      $items = field_get_items('node', $node, $field_name);
-      if (is_array($items) && !empty($items)) {
-        $item = reset($items);
-        $mapping['fields'][$field_name] = [
-          'name' => 'Event status label',
-          'value' => $item['value'],
-          'attr' => [],
-        ];
-      }
-
       $tag_field = 'field_ding_event_tags';
       break;
 

--- a/modules/ding_mobilesearch/ding_mobilesearch.module
+++ b/modules/ding_mobilesearch/ding_mobilesearch.module
@@ -156,6 +156,17 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
         'value' => $node->status,
         'attr' => array(),
       ),
+      // Having a text index in the database and passing the language as a part
+      // of the node payload, will result in an
+      // "insertDocument :: caused by :: 17261 found language override field
+      // in document with non-string type" error.
+      // See: https://docs.mongodb.com/manual/tutorial/specify-language-for-text-index/
+      // Possible solutions:
+      // - disable text index entirely for respective collection;
+      // - override the source field of content language for the appropriate
+      // index definition;
+      // - provide a two digit language code as this field value,
+      // without the generic structure of an array with name/value/attr keys.
       'language' => array(
         'name' => t('Language'),
         'value' => !empty($node->language) ? $node->language : 'en',
@@ -403,6 +414,30 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
           ),
         );
       }
+
+      // TODO: Separate method to fill in the mapping.
+      $field_name = 'field_ding_event_status_label';
+      $items = field_get_items('node', $node, $field_name);
+      if (is_array($items) && !empty($items)) {
+        $item = reset($items);
+        $mapping['fields'][$field_name] = [
+          'name' => 'Event status label',
+          'value' => $item['value'],
+          'attr' => [],
+        ];
+      }
+
+      $field_name = 'field_ding_event_status_color';
+      $items = field_get_items('node', $node, $field_name);
+      if (is_array($items) && !empty($items)) {
+        $item = reset($items);
+        $mapping['fields'][$field_name] = [
+          'name' => 'Event status label',
+          'value' => $item['value'],
+          'attr' => [],
+        ];
+      }
+
       $tag_field = 'field_ding_event_tags';
       break;
 


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1237

#### Description

Nothing to be done. Fields of that type are covered by default and are pushed automatically.

#### Screenshot of the result
![image](https://user-images.githubusercontent.com/574498/86463726-b8879b80-bd36-11ea-9dd8-7989604bae8c.png)
![image](https://user-images.githubusercontent.com/574498/86463712-b1f92400-bd36-11ea-9135-2de9e387707b.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Left a note in code in regards to pushing specifics when mongo uses a text-index.
