### PR TITLE
EASYOPAC-1226 - Ease the debug info.

### DIFF
--- a/modules/ding_mobilesearch/plugins/rest.inc
+++ b/modules/ding_mobilesearch/plugins/rest.inc
@@ -55,6 +55,9 @@ function ding_mobilesearch_rest_service_call($method, $body = array()) {
     );
     return NULL;
   }
+
+  $response = NULL;
+
   try {
     $instance->$method($request);
     $response = $instance->getResponse();
@@ -64,14 +67,22 @@ function ding_mobilesearch_rest_service_call($method, $body = array()) {
   }
 
   if ($debug) {
+    // Truncate long data so it doesn't clutter the dblog.
+    array_walk_recursive($request, function(&$element) {
+      if (drupal_strlen($element) > 512) {
+        $element = truncate_utf8($element, 512, TRUE, TRUE);
+      }
+    });
+
     watchdog(
       'rest_plugin',
-      'Method: <strong>!method</strong>. Request: <pre>!request</pre>Response: <pre>!response</pre>',
-      array(
+      '<strong>Method:</strong> !method<br /> <strong>Endpoint:</strong> !endpoint<br /><strong>Response:</strong><pre>!response</pre><strong>Payload:</strong><pre>!request</pre>',
+      [
+        '!endpoint' => $service_url,
         '!method' => $method,
         '!request' => var_export($request, TRUE),
         '!response' => var_export($response, TRUE),
-      ),
+      ],
       WATCHDOG_DEBUG
     );
   }


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1226

#### Description

When _mobilesearch_ push debug is on, it is logging the full payload into the _dblog_. So whether an image was a part the payload it would eventually be written into the log as a huge base64 encoded data. This could possibly result in mysql failure, like _gone away_ error. The change-set, limits the logged data to a reasonable value.

#### Screenshot of the result

Before:
![image](https://user-images.githubusercontent.com/574498/86466512-6d708700-bd3c-11ea-8a94-d08052364533.png)
After:
![image](https://user-images.githubusercontent.com/574498/86466568-85480b00-bd3c-11ea-91bf-e85cdb162d2e.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

None.
