### PR TITLE
EASYOPAC-1235 - Custom hack for the smartbanner module

### DIFF
--- a/modules/ding_app_smartbanner/ding_app_smartbanner.admin.inc
+++ b/modules/ding_app_smartbanner/ding_app_smartbanner.admin.inc
@@ -146,7 +146,7 @@ function ding_app_smartbanner_settings_form($form, &$form_state) {
       '#type' => 'textfield',
       '#title' => t("@os_name app id", array('@os_name' => $os_name)),
       '#size' => 30,
-      '#maxlength' => 30,
+      '#maxlength' => 60,
       '#required' => FALSE,
       '#default_value' => !empty($app_config['app_id']) ? $app_config['app_id'] : '',
     );

--- a/modules/ding_app_smartbanner/js/ding_app_smartbanner.js
+++ b/modules/ding_app_smartbanner/js/ding_app_smartbanner.js
@@ -19,19 +19,21 @@
           }
         });
 
-        new SmartBanner({
-          daysHidden: Drupal.settings.ding_app_smartbanner.days_hidden,   // days to hide banner after close button is clicked (defaults to 15)
-          daysReminder: Drupal.settings.ding_app_smartbanner.days_reminder, // days to hide banner after "VIEW" button is clicked (defaults to 90)
-          appStoreLanguage: Drupal.settings.ding_app_smartbanner.app_store_language, // language code for the App Store (defaults to user's browser language)
-          title: Drupal.settings.ding_app_smartbanner.app_title,
-          author: Drupal.settings.ding_app_smartbanner.app_author,
-          button: Drupal.settings.ding_app_smartbanner.button_name,
-          store: store,
-          price: price,
-          icon: ding_app_smartbanner.app_icon.icon_path
-        });
+        var ua = navigator.userAgent;
+        if (ua.match(/bibliofil/gi) === null) {
+          new SmartBanner({
+            daysHidden: Drupal.settings.ding_app_smartbanner.days_hidden,   // days to hide banner after close button is clicked (defaults to 15)
+            daysReminder: Drupal.settings.ding_app_smartbanner.days_reminder, // days to hide banner after "VIEW" button is clicked (defaults to 90)
+            appStoreLanguage: Drupal.settings.ding_app_smartbanner.app_store_language, // language code for the App Store (defaults to user's browser language)
+            title: Drupal.settings.ding_app_smartbanner.app_title,
+            author: Drupal.settings.ding_app_smartbanner.app_author,
+            button: Drupal.settings.ding_app_smartbanner.button_name,
+            store: store,
+            price: price,
+            icon: ding_app_smartbanner.app_icon.icon_path
+          });
+        }
       }
-
     }
   };
 })(jQuery);


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1235

#### Description

In the Bibliofil-project, the smartbanner is shown when running inside the Application itself and calling to install this. As the Bibliofil app developers added customized User Agent string ``` "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Bibliofil MappaMiWebApp - iOS"```, we will look into User Agent string and if it will match "bibliofil" key, we'll skip initialization of smart banner.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
