### PR TITLE
EASYOPAC-1231 - Webform should be inserted right after Paragraphs.

### DIFF
--- a/modules/ding_news/ding_news.strongarm.inc
+++ b/modules/ding_news/ding_news.strongarm.inc
@@ -129,7 +129,7 @@ function ding_news_strongarm() {
             'visible' => TRUE,
           ),
           'default' => array(
-            'weight' => '13',
+            'weight' => '10',
             'visible' => TRUE,
           ),
           'search_result' => array(


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1231

#### Description

Right now, the webform field is inserted as the last element on a node CT. It means that user think the "article is finished". The webform should be moved right after Paragraph / before Files.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.