### PR TITLE
EASYOPAC-1245 - Hide description of items in carousel.

### DIFF
--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -324,7 +324,7 @@ function ting_search_carousel_image_default_styles() {
  */
 function ting_search_carousel_preprocess_ding_carousel_item(&$variables) {
   // Hide ting_abstract field.
-  $variables["content"]["ting_abstract"]["#access"] = FALSE;
+  $variables['content']['ting_abstract']['#access'] = FALSE;
 }
 
 /**

--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -320,6 +320,14 @@ function ting_search_carousel_image_default_styles() {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function ting_search_carousel_preprocess_ding_carousel_item(&$variables) {
+  // Hide ting_abstract field.
+  $variables["content"]["ting_abstract"]["#access"] = FALSE;
+}
+
+/**
  * Represents a search for the carousel.
  *
  * Encapsulates query and sort.


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1245

#### Description

Carousel item's description is not readable after changes made for displaying smaller cover images.
This PR hides ting_object's ```ting_abstract``` field for carousel items.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.