### PR TITLE
EASYOPAC-1244 - Make price field non-mandatory.

### DIFF
--- a/modules/ding_event/ding_event.features.field_instance.inc
+++ b/modules/ding_event/ding_event.features.field_instance.inc
@@ -936,8 +936,6 @@ function ding_event_field_default_field_instances() {
         'label' => 'above',
         'module' => 'text',
         'settings' => array(),
-        'type' => 'number_integer',
-        'weight' => 8,
         'type' => 'text_default',
         'weight' => 3,
       ),
@@ -969,7 +967,7 @@ function ding_event_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_ding_event_price',
     'label' => 'Price',
-    'required' => 1,
+    'required' => 0,
     'settings' => array(
       'suffix' => ' kr.',
       'text_processing' => 0,


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1244

#### Description

The price field in Event CT is mandatory. This is creating some kind of misunderstanding because in more places we can notice that ```if you leave field blank it will say "Free"```, but real situation is that user if forced to fill this field otherwise he can't save node.
This commit makes "Price" field non-mandatory.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.