### PR TITLE
EO-NOTASK - Display Address 2 line on library overview.

### DIFF
--- a/modules/ding_library/plugins/content_types/address.inc
+++ b/modules/ding_library/plugins/content_types/address.inc
@@ -20,7 +20,7 @@ function ding_library_address_content_type_render($subtype, $conf, $panel_args, 
   $content = ' <div class="library-address">';
   if (!empty($node->field_ding_library_addresse['und'])) {
     $content .= '
-      <div class="library-address-street">' . $node->field_ding_library_addresse['und'][0]['thoroughfare'] . '</div>
+      <div class="library-address-street">' . $node->field_ding_library_addresse[LANGUAGE_NONE][0]['thoroughfare'] . '<br />' . $node->field_ding_library_addresse[LANGUAGE_NONE][0]['premise'] . '</div>
       <div class="library-address-city-wrapper">
         <span class="library-address-postal-code">' . $node->field_ding_library_addresse['und'][0]['postal_code'] . '</span><span class="library-address-city">' . $node->field_ding_library_addresse['und'][0]['locality'] . '</span>
       </div>';


### PR DESCRIPTION
#### Description

The "Address 2" field of Library CT was not displayed on the library overview page.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
