### PR TITLE
BS-37 - Add <b> tag as allowed to ding_wysiwyg text format.

### DIFF
--- a/modules/ding_content/ding_content.features.filter.inc
+++ b/modules/ding_content/ding_content.features.filter.inc
@@ -52,7 +52,7 @@ function ding_content_filter_default_formats() {
         'weight' => -45,
         'status' => 1,
         'settings' => array(
-          'allowed_html' => '<a> <p> <em> <strong> <cite> <blockquote> <ul> <ol> <li> <dl> <dt> <dd> <table> <tr> <th> <td> <br> <img> <iframe> <h2> <h3> <h4> <h5> <h6> <div> <audio> <source> <address> <pre> <u> <script> <style> <object> <param> <embed> <video> <audio>',
+          'allowed_html' => '<a> <b> <p> <em> <strong> <cite> <blockquote> <ul> <ol> <li> <dl> <dt> <dd> <table> <tr> <th> <td> <br> <img> <iframe> <h2> <h3> <h4> <h5> <h6> <div> <audio> <source> <address> <pre> <u> <script> <style> <object> <param> <embed> <video> <audio>',
           'filter_html_help' => 1,
           'filter_html_nofollow' => 0,
         ),


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/BS-37

#### Description

<b> tag was excluded from rendering on content display.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
