### PR TITLE
EASYOPAC-1263 - Invoke entity buttons consequently.

### DIFF
--- a/modules/ting/js/ting_ding_entity_buttons.js
+++ b/modules/ting/js/ting_ding_entity_buttons.js
@@ -34,26 +34,38 @@
 
       // Identifiers object is keyed with button types, therefore loop
       // the types and send ajax request for each.
-      for (var i in identifiers) {
+      for (let i in identifiers) {
         if (identifiers[i].length === 0) {
-          continue;
+          delete identifiers[i];
         }
+      }
 
-        $this.renderDingEntityButtons(identifiers[i], i);
+      $this.renderDingEntityButtons(identifiers);
+    },
+
+    renderDingEntityButtons: async function (identifiers) {
+      for (let i in identifiers) {
+        await this.sendButtonAjaxRequest(identifiers[i], i).then(() => {});
       }
     },
 
-    renderDingEntityButtons: function (identifiers, type) {
-      var element_settings = {
-        url: '/ting/ding_entity_buttons/nojs/' + type,
-        submit: {
-          'js': true,
-          'identifiers[]': identifiers
-        }
-      };
+    sendButtonAjaxRequest: function (identifier, type) {
+      return new Promise(resolve => {
+        var element_settings = {
+          url: '/ting/ding_entity_buttons/nojs/' + type,
+          submit: {
+            'js': true,
+            'identifiers[]': identifier
+          },
+          success: function (response, status) {
+            resolve();
+            Drupal.ajax.prototype.success.apply(this, arguments);
+          }
+        };
 
-      var ajax = new Drupal.ajax(null, document.body, element_settings);
-      ajax.eventResponse(ajax, {});
+        var ajax = new Drupal.ajax(null, document.body, element_settings);
+        ajax.eventResponse(ajax, {});
+      });
     }
   };
 }(jQuery));


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1263

#### Description

Ding entity buttons might happen to be invoked simultaneously, which might create a case when database tries to write same record twice. This eventually triggers database exception regarding duplicate values.

#### Screenshot of the result

None.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR would simply make entity buttons wait each other and run consequently.
