### PR TITLE
EASYOPAC-1271 - Re-attach behaviors on availability processing.

### DIFF
--- a/modules/ding_availability/js/ding_availability.js
+++ b/modules/ding_availability/js/ding_availability.js
@@ -58,6 +58,7 @@
             });
 
             $(document).trigger('ding_availability_update_holdings');
+            Drupal.attachBehaviors(context);
           },
           error: function () {
             $('div.loader').remove();

--- a/modules/ding_availability/js/ding_availability_labels.js
+++ b/modules/ding_availability/js/ding_availability_labels.js
@@ -94,9 +94,9 @@
           element.removeClass('pending').addClass('processed');
         }
 
-        // Get hold of the reserve button (it hidden as default, so we may need
+        // Get hold of the reserve button on collection items (it hidden as default, so we may need
         // to show it).
-        var reserver_btn = element.parents('.ting-object:first').find('.reserve-button');
+        var reserver_btn = element.parents('.ting-collection-wrapper').find('.reserve-button');
 
         update_availability_elements(element, reserver_btn, status);
       }

--- a/modules/ding_availability/js/ding_availability_labels.js
+++ b/modules/ding_availability/js/ding_availability_labels.js
@@ -94,11 +94,7 @@
           element.removeClass('pending').addClass('processed');
         }
 
-        // Get hold of the reserve button on collection items (it hidden as default, so we may need
-        // to show it).
-        var reserver_btn = element.parents('.ting-collection-wrapper').find('.reserve-button');
-
-        update_availability_elements(element, reserver_btn, status);
+        update_availability_elements(element, status);
       }
 
       /**
@@ -185,7 +181,7 @@
        * @param status
        *   Structure with available and reservable state.
        */
-      function update_availability_elements(element, btn, status) {
+      function update_availability_elements(element, status) {
         var class_name = null;
 
         for (var i in status) {
@@ -193,9 +189,6 @@
             class_name = i;
           }
           element.addClass(class_name);
-          if (btn.length) {
-            btn.addClass(class_name);
-          }
         }
 
         update_availability_type(element, status);

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -199,12 +199,15 @@ function fbs_reservation_create($account, $record_id, array $options) {
       case 'material_lost':
       case 'material_not_found':
       case 'material_part_of_collection':
+      case 'not_reservable':
+      case 'no_reservable_materials':
+      case 'interlibrary_material_not_reservable':
         throw new DingProviderReservationNotAvailable();
 
       // Success shouldn't happen.
       case 'success':
       default:
-        watchdog('fbs', 'Unexpected state "@state" on failed reservaiton', array('@state' => $result->result), WATCHDOG_WARNING);
+        watchdog('fbs', 'Unexpected state "@state" on failed reservation', array('@state' => $result->result), WATCHDOG_WARNING);
         throw new DingProviderEnduserException(t('Unknown error from library system while attempting to reserve.'));
     };
   }


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1271

#### Description

On non-cached material item page render which has periodical issues available for reservation, reservation link's 'use-ajax' class wasn't processed correctly and 'ajax-processed' class wasn't added and as a result the ajaxify functionality wasn't triggered.
The forced attaching of Drupal behaviors fixes this.
Also in this PR were added missing response types returned from FBS and fixed reservation buttons behavior.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
