### PR TITLE
EASYOPAC-1276 - Remove video support for nodelist's tabroll.

### DIFF
--- a/modules/ding_nodelist/css/ding_nodelist.css
+++ b/modules/ding_nodelist/css/ding_nodelist.css
@@ -73,11 +73,7 @@
     opacity: 1;
   }
 }
-.ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-prev:after, .ding_nodelist-carousel .icon-next::after, .ding_nodelist-carousel .icon-next:after, .ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-carousel .pn-media-play i:after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i:after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i:after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i:after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i:after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i:after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-prev:after, .ding_nodelist-carousel .icon-next::after, .ding_nodelist-carousel .icon-next:after, .ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-carousel .pn-media-play i:after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i:after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
@@ -102,13 +98,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
+.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
   content: "\e907";
 }
 
-.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
+.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
   content: "\e907";
 }
 
@@ -120,8 +114,7 @@
   content: "\e909";
 }
 
-.ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i::after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
@@ -132,11 +125,7 @@
   content: "\e91a";
 }
 
-.ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-prev:after, .ding_nodelist-carousel .icon-next::after, .ding_nodelist-carousel .icon-next:after, .ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-carousel .pn-media-play i:after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i:after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i:after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i:after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i:after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i:after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-prev:after, .ding_nodelist-carousel .icon-next::after, .ding_nodelist-carousel .icon-next:after, .ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-carousel .pn-media-play i:after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-carousel .has-video .media-container .pn-close-media i:after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
@@ -161,13 +150,11 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
+.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
   content: "\e907";
 }
 
-.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
+.ding_nodelist-carousel .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
   content: "\e907";
 }
 
@@ -179,8 +166,7 @@
   content: "\e909";
 }
 
-.ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i::after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-carousel .pn-media-play i::after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
@@ -670,92 +656,6 @@
 }
 .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs-nav {
   margin-bottom: 10px;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play {
-  font-size: 180%;
-  position: absolute;
-  right: 15px;
-  bottom: 15px;
-  background: #fff;
-  border-radius: 100px;
-  width: 35px;
-  height: 35px;
-  text-align: center;
-  cursor: pointer;
-  z-index: 50;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i {
-  font-style: normal;
-  position: relative;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i::after {
-  font-size: 54px;
-  line-height: 1;
-  color: #4d898e;
-  display: block;
-  position: absolute;
-  top: 0;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .pn-media-play i:after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .pn-media-play i:after {
-  font-size: 28px;
-  top: 0;
-  position: relative;
-  display: inline-block;
-  margin-top: 4px;
-  margin-left: 4px;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  height: 100%;
-  width: 100%;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media {
-  position: absolute;
-  z-index: 100;
-  color: #fff;
-  top: 15px;
-  left: 15px;
-  display: none;
-  width: 36px;
-  height: 36px;
-  background: #fff;
-  border-radius: 100px;
-  cursor: pointer;
-  text-align: center;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i {
-  font-style: normal;
-  position: relative;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i::after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i::after {
-  font-size: 54px;
-  line-height: 1;
-  color: #4d898e;
-  display: block;
-  position: absolute;
-  top: 0;
-}
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper .ui-tabs .has-video .media-container .pn-close-media i:after,
-.ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.ui-tabs-panel .has-video .media-container .pn-close-media i:after {
-  font-size: 54px;
-  top: 0;
-  line-height: 1;
-  margin-top: -9px;
-  margin-left: -9px;
-  font-weight: bolder;
-  position: relative;
 }
 .ding_nodelist-rolltab .ding_nodelist-rolltab-wrapper div.image span.no-image {
   background-color: #fff;
@@ -2309,5 +2209,3 @@ table td.minimal-title {
 table td.minimal-title td.minimal-date {
   width: 20%;
 }
-
-/*# sourceMappingURL=ding_nodelist.css.map */

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -971,7 +971,6 @@ function _ding_nodelist_add_js($widget, $autoscroll_delay = NULL, $unique_id = N
 
     case DING_NODELIST_WIDGET_ROLLTAB:
       ding_tabroll_add_js($autoscroll_delay);
-      drupal_add_js($mod_path . '/js/video.js', 'file');
       break;
 
     case DING_NODELIST_WIDGET_NODE_BLOCKS:

--- a/modules/ding_nodelist/js/video.js
+++ b/modules/ding_nodelist/js/video.js
@@ -99,11 +99,6 @@
                 data.height = Math.round(top.height()) + 'px';
                 $(wrapper).find('.ding_nodelist-items').slick('slickPause');
                 break;
-
-              case 'rolltab':
-                top = $this.parent();
-                data.height = Math.round(top.height()) + 'px';
-                break;
             }
 
             let url = NodelistVideo.getVideoUrl(top);

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -242,7 +242,6 @@ $label-bg: url('../images/p.png');
 
     &:after {
       display: inline-block;
-//      line-height: 1.5;
       width: 50px;
       height: 50px;
       font-size: 30px;
@@ -507,80 +506,6 @@ $label-bg: url('../images/p.png');
 
     .ui-tabs-nav {
       margin-bottom: 10px;
-    }
-
-    .ui-tabs,
-    div.ui-tabs-panel {
-      .pn-media-play {
-        font-size: 180%;
-        position: absolute;
-        right: 15px;
-        bottom: 15px;
-        background: #fff;
-        border-radius: 100px;
-        width: 35px;
-        height: 35px;
-        text-align: center;
-        cursor: pointer;
-        z-index: 50;
-
-        i {
-          font-style: normal;
-          @include place-icon(play, $color-primary);
-
-          &:after {
-            @extend %icomoon-base;
-            font-size: 28px;
-            top: 0;
-            position: relative;
-            display: inline-block;
-            margin-top: 4px;
-            margin-left: 4px;
-          }
-        }
-      }
-
-      .has-video {
-        .media-container {
-          position: absolute;
-          left: 0;
-          right: 0;
-          top: 0;
-          bottom: 0;
-          height: 100%;
-          width: 100%;
-
-          .pn-close-media {
-            position: absolute;
-            z-index: 100;
-            color: #fff;
-            top: 15px;
-            left: 15px;
-            display: none;
-            width: 36px;
-            height: 36px;
-            background: #fff;
-            border-radius: 100px;
-            cursor: pointer;
-            text-align: center;
-            i {
-              font-style: normal;
-              @include place-icon(close, $color-primary);
-
-              &:after {
-                font-size: 54px;
-                top: 0;
-                line-height: 1;
-                margin-top: -9px;
-                margin-left: -9px;
-                font-weight: bolder;
-                position: relative;
-                @extend %icomoon-base;
-              }
-            }
-          }
-        }
-      }
     }
 
     div.image {

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.rolltab.tpl.php
@@ -7,25 +7,8 @@
  * @var array $item
  */
 
-$video_player = '';
-if (isset($item->video)) {
-  $video_player = '<div class="media-container">';
-  $video_player .= '<div class="media-content" data-url="' . $item->video . '" data-service="' . $item->video_service . '"></div>';
-  $video_player .= '<div class="pn-close-media"><i class="icon-cross"></i></div>';
-  $video_player .= '</div>';
-}
-
-$video_play_btn = '';
-if (isset($item->video)) {
-  $video_play_btn = "<div class='pn-media-play'><div class='pn-play pn-round'><i class='icon-play'></i></div></div>";
-}
-
-$classes = ['<?php print $classes; ?>'];
-$classes[] = (isset($item->video) ? 'has-video' : NULL);
-$classes = implode(' ', $classes);
 ?>
-<div class="<?php print $classes; ?>">
-  <?php print $video_player; ?>
+<div class="ui-tabs-panel">
   <div class="image">
     <?php if (!$item->image): ?>
       <span class="no-image"></span>
@@ -37,5 +20,4 @@ $classes = implode(' ', $classes);
     <h3><?php print l($item->title, 'node/' . $item->nid); ?></h3>
     <p><?php print $item->teaser_lead; ?></p>
   </div>
-  <?php print $video_play_btn; ?>
 </div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_page.rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_page.rolltab.tpl.php
@@ -19,25 +19,8 @@ if (!empty($body) && substr($body, 0, 2) === '<p') {
   $p_body_wrapper = FALSE;
 }
 
-$video_player = '';
-if (isset($item->video)) {
-  $video_player = '<div class="media-container">';
-  $video_player .= '<div class="media-content" data-url="' . $item->video . '" data-service="' . $item->video_service . '"></div>';
-  $video_player .= '<div class="pn-close-media"><i class="icon-cross"></i></div>';
-  $video_player .= '</div>';
-}
-
-$video_play_btn = '';
-if (isset($item->video)) {
-  $video_play_btn = "<div class='pn-media-play'><div class='pn-play pn-round'><i class='icon-play'></i></div></div>";
-}
-
-$classes = ['ui-tabs-panel'];
-$classes[] = (isset($item->video) ? 'has-video' : NULL);
-$classes = implode(' ', $classes);
 ?>
-<div class="<?php print $classes; ?>"<?php print $attributes; ?>>
-  <?php print $video_player; ?>
+<div class="ui-tabs-panel"<?php print $attributes; ?>>
   <div class="image">
     <?php if (!$item->image): ?>
       <span class="no-image"></span>
@@ -55,5 +38,4 @@ $classes = implode(' ', $classes);
       </p>
     <?php endif; ?>
   </div>
-  <?php print $video_play_btn; ?>
 </div>

--- a/modules/ding_nodelist/templates/ding_nodelist_widget_rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist_widget_rolltab.tpl.php
@@ -17,7 +17,7 @@
 
 ?>
 <?php if ($items): ?>
-  <div class="<?php print $conf['classes'] ?>" data-widget-type="rolltab">
+  <div class="<?php print $conf['classes'] ?>">
     <div class="ding_nodelist-items">
       <div class="ding_nodelist-rolltab-wrapper ding-tabroll-wrapper">
         <div class="ding_nodelist-rolltab ding-tabroll">

--- a/modules/ding_tabroll/ding_tabroll.module
+++ b/modules/ding_tabroll/ding_tabroll.module
@@ -65,9 +65,6 @@ function ding_tabroll_add_js($switch_speed = null) {
   // Add default CSS and JavaScript.
   drupal_add_js($path . '/js/ding_tabroll.js');
 
-  // Add video support.
-  drupal_add_js($path . '/js/video.js');
-
   drupal_add_js(array('ding_tabroll' => array('switch_speed' => $switch_speed)), 'setting');
 }
 


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1276

#### Description

Remove support of videos in Ding Nodelist's rolltab widget.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.