### PR TITLE
EASYOPAC-1292 - Search expand button is not working on item page.

### DIFF
--- a/modules/ding_availability/js/ding_availability.js
+++ b/modules/ding_availability/js/ding_availability.js
@@ -58,7 +58,6 @@
             });
 
             $(document).trigger('ding_availability_update_holdings');
-            Drupal.attachBehaviors(context);
           },
           error: function () {
             $('div.loader').remove();


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1292

#### Description

Search expand button was not working on item page because the `Drupal.attachBehaviors()` in ding_availability.js was duplicating called actions, so as for search expand button was used jQuery `toggle()` function this on click was called twice.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.