### PR TITLE
EASYOPAC-1293 - Fix nodes sorting by 'creation date'.

### DIFF
--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1253,11 +1253,12 @@ function _ding_nodelist_sort_nodes(array $nodes, array $conf) {
         $sorted_nodes[][$date] = $node;
       }
       elseif ($conf['sort_field'] == DING_NODELIST_SORT_BY_CREATION_DATE) {
+        $node_created = $node->created;
         if (array_key_exists($node->created, $sorted_nodes)) {
           $index = $i++ ?? (int) 0;
-          $node->created = $node->created . '_' . $index;
+          $node_created = $node_created . '_' . $index;
         }
-        $sorted_nodes[$node->created] = $node;
+        $sorted_nodes[$node_created] = $node;
       }
       elseif ($conf['sort_field'] == DING_NODELIST_SORT_BY_TITLE) {
         $sorted_nodes[$node->title] = $node;

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1243,6 +1243,7 @@ function _ding_nodelist_sort_query(&$query, array $conf) {
  */
 function _ding_nodelist_sort_nodes(array $nodes, array $conf) {
   if ($conf['sort_field']) {
+    $i = 0;
     $sorted_nodes = array();
     foreach ($nodes as $node) {
       // Prepare for custom sorting.
@@ -1252,6 +1253,10 @@ function _ding_nodelist_sort_nodes(array $nodes, array $conf) {
         $sorted_nodes[][$date] = $node;
       }
       elseif ($conf['sort_field'] == DING_NODELIST_SORT_BY_CREATION_DATE) {
+        if (array_key_exists($node->created, $sorted_nodes)) {
+          $index = $i++ ?? (int) 0;
+          $node->created = $node->created . '_' . $index;
+        }
         $sorted_nodes[$node->created] = $node;
       }
       elseif ($conf['sort_field'] == DING_NODELIST_SORT_BY_TITLE) {


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1293

#### Description

The issue belongs to wrong sorting logic of nodes by creation date, because it didn't take in consideration the aspect that creation date can be the same for multiple nodes.
Here we are checking if the already sorted nodes have the same key as processed node's created date, if this is true - then adding iteration counter to the array key.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.