### PR TITLE
EASYOPAC-1298 - Delete stale variables and settings from database.

### DIFF
--- a/modules/ding_mobilesearch/ding_mobilesearch.install
+++ b/modules/ding_mobilesearch/ding_mobilesearch.install
@@ -46,11 +46,17 @@ function ding_mobilesearch_uninstall() {
     variable_del($key);
     variable_del($key . '__trigger');
     variable_del($key . '__plugin');
+
+    variable_del('flag_push_to_mongo_default_' . $type);
   }
   variable_del('mobilesearch_rest_url');
   variable_del('mobilesearch_rest_debug');
   variable_del('mobilesearch_rest_agency_id');
   variable_del('mobilesearch_rest_key');
+
+  db_delete('flags')
+    ->condition('name', 'push_to_mongo')
+    ->execute();
 }
 
 /**

--- a/modules/ding_mobilesearch/ding_mobilesearch.install
+++ b/modules/ding_mobilesearch/ding_mobilesearch.install
@@ -54,9 +54,8 @@ function ding_mobilesearch_uninstall() {
   variable_del('mobilesearch_rest_agency_id');
   variable_del('mobilesearch_rest_key');
 
-  db_delete('flags')
-    ->condition('name', 'push_to_mongo')
-    ->execute();
+  $flag = flag_load('push_to_mongo');
+  $flag->delete();
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1298

#### Description

Modified `ding_mobilesearch` `hook_uninstall()` so on module uninstalling the variables used by `flag` module are deleted and also `push_to_mongo` flag option is deleted from database table.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.