### PR TITLE
EONO-7 - Extending ding2 profile installer with new steps.

### DIFF
--- a/ding2.bibliofil.inc
+++ b/ding2.bibliofil.inc
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * @file
+ * Ding2 profile installation altering for Bibliofil projects.
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function ding2_form_ding2_module_selection_form_alter(&$form, &$form_state, $form_id) {
+  $form['providers']['providers_selection']['#options']['lms'] = 'LMS';
+  $form['providers']['providers_selection']['#default_value'] = 'lms';
+}
+
+/**
+ * Implements hook_ding_install_tasks().
+ */
+function ding2_ding_install_tasks() {
+  return [
+    'ding2_bibliofil_modules_enable' => [
+      'display_name' => st('Bibliofil: Enabling modules'),
+      'display' => TRUE,
+      'type' => 'batch',
+      'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
+    ],
+    'ding2_bibliofil_localization' => [
+      'display_name' => st('Bibliofil: Localizing'),
+      'display' => TRUE,
+      'type' => 'batch',
+      'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
+    ],
+    'ding2_bibliofil_modules_disable' => [
+      'display_name' => st('Bibliofil: Disable modules'),
+      'display' => TRUE,
+      'run' => INSTALL_TASK_RUN_IF_NOT_COMPLETED,
+      'type' => 'batch',
+    ],
+  ];
+}
+
+/**
+ * Enable modules.
+ *
+ * @param array $install_state
+ *   Install state.
+ *
+ * @return array
+ *   Batch operation.
+ */
+function ding2_bibliofil_modules_enable(&$install_state) {
+  $modules = [
+    'add_to_head',
+    'easyddb_frontend_layout',
+    'easyopac_nodereferences',
+    'easyopac_redirect',
+    'easyddb_dams',
+    'easyddb_dams_media_browser',
+    'dams_media_tracker',
+    'easyddb_dams_taxonomy',
+    'lms',
+    'lms_covers',
+    'ding_node_search_autocomplete',
+    'bibliofil_lists',
+    'i18n_menu',
+    'i18n_contact',
+    'i18n_taxonomy',
+  ];
+
+  $ops = ding2_module_list_as_operations($modules);
+
+  return [
+    'title' => st('Installing Bibliofil dependencies'),
+    'operations' => $ops,
+    'file' => drupal_get_path('profile', 'ding2') . '/ding2.install_callbacks.inc',
+  ];
+}
+
+/**
+ * Disable modules.
+ *
+ * @param array $install_state
+ *   Install state.
+ *
+ * @return array
+ *   Batch operation.
+ */
+function ding2_bibliofil_modules_disable(&$install_state) {
+  $ops = [];
+
+  $modules = [
+    'eck',
+    'opensearch',
+    'ting_field_search',
+    'ting_fulltext',
+    'ting_infomedia',
+    'ting_smart_search',
+    'ting_subsearch',
+    'ting_subsearch_suggestions',
+    'varnish',
+  ];
+
+  $ops[] = [
+    'module_disable',
+    [
+      $modules,
+      TRUE,
+    ],
+  ];
+
+  return [
+    'title' => st('Disable non-Bibliofil modules'),
+    'operations' => $ops,
+  ];
+}
+
+/**
+ * Localize the bibliofil.
+ *
+ * @param array $install_state
+ *   Install state.
+ *
+ * @return array
+ *   Batch operation.
+ */
+function ding2_bibliofil_localization(&$install_state) {
+  $ops = [];
+  $langcode = 'nb';
+  $translations_path = '/profiles/ding2/modules/bibliofil_common/translations/';
+
+  // Enable and set as default Norwegian language.
+  include_once DRUPAL_ROOT . '/includes/locale.inc';
+  locale_add_language($langcode, NULL, NULL, NULL, '', NULL, TRUE, TRUE);
+
+  $languages = language_list();
+  variable_set('language_default', $languages[$langcode]);
+
+  $translations = [
+    'default' => 'nb.po',
+    'field' => 'felt.nb.po',
+    'menu' => 'menu.nb.po',
+    'contact' => 'kontakt.nb.po',
+    'taxonomy' => 'taxonomy.nb.po',
+    'metatag' => 'metatag.nb.po',
+  ];
+
+  foreach ($translations as $type => $file) {
+    $ops[] = [
+      '_ding2_bibliofil_insert_translation',
+      [
+        $type,
+        $translations_path . $file,
+      ],
+    ];
+  }
+
+  return [
+    'title' => st('Installing Bibliofil translations'),
+    'operations' => $ops,
+  ];
+}
+
+/**
+ * Import translations.
+ */
+function _ding2_bibliofil_insert_translation($type, $translation_file, &$context) {
+  $file = new stdClass();
+  $file->uri = DRUPAL_ROOT . $translation_file;
+  $file->filename = basename($file->uri);
+
+  _locale_import_po($file, 'nb', LOCALE_IMPORT_OVERWRITE, $type);
+  $context['message'] = st('Installed %type translation.', ['%type' => $type]);
+}

--- a/ding2.profile
+++ b/ding2.profile
@@ -9,6 +9,9 @@
 !function_exists('profiler_v2') ? require_once 'libraries/profiler/profiler.inc' : FALSE;
 profiler_v2('ding2');
 
+// Include ding2 alterations, related to Bibliofil.
+include 'ding2.bibliofil.inc';
+
 /**
  * Implements hook_form_FORM_ID_alter().
  *

--- a/easyopac.make
+++ b/easyopac.make
@@ -19,6 +19,13 @@ projects[bibliofil_lists][download][url]    = "git@github.com:easySuite/bibliofi
 ;projects[bibliofil_lists][download][tag]    = ""
 projects[bibliofil_lists][download][branch] = "development"
 
+projects[bibliofil_common][type]             = "module"
+projects[bibliofil_common][subdir]           = ""
+projects[bibliofil_common][download][type]   = "git"
+projects[bibliofil_common][download][url]    = "git@github.com:easySuite/bibliofil_common.git"
+;projects[bibliofil_common][download][tag]    = ""
+projects[bibliofil_common][download][branch] = "development"
+
 projects[ding_billetexpressen_import][type]             = "module"
 projects[ding_billetexpressen_import][subdir]           = ""
 projects[ding_billetexpressen_import][download][type]   = "git"


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EONO-7

#### Description

Added additional steps into ding2 profile installer which will automatically enable required modules, add Norwegian language and import localization files and disable un-needed modules.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Localization files will be kept in easySuite/bibliofil_common repo.