### PR TITLE
EASYOPAC-1328 - Fetch cover by Faust instead of PID.

### DIFF
--- a/modules/ting_covers/ting_covers.theme.inc
+++ b/modules/ting_covers/ting_covers.theme.inc
@@ -22,7 +22,7 @@ function template_preprocess_ting_object_cover(&$variables) {
     'ting-cover',
   );
   $variables['data'] = array(
-    'ting-cover-object-id' => $object->id,
+    'ting-cover-object-id' => $object->provider_id,
     'ting-cover-style' => $variables['image_style'],
   );
   $variables['image'] = '';

--- a/modules/ting_covers_addi/ting_covers_addi.module
+++ b/modules/ting_covers_addi/ting_covers_addi.module
@@ -51,7 +51,7 @@ function ting_covers_addi_ting_covers($entities) {
     $service = new AdditionalInformationService(variable_get('ting_covers_addi_wsdl_url'), variable_get('ting_covers_addi_username'), variable_get('ting_covers_addi_group'), variable_get('ting_covers_addi_password'), variable_get('ting_covers_addi_enforce_url', FALSE));
 
     // Retrieve covers by PID.
-    $retrieved = $service->getByPid(array_keys($entities));
+    $retrieved = $service->getByFaustNumber(array_keys($entities));
 
     foreach ($retrieved as $pid=> $cover) {
       // Try to extract the image url from the result.


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1328

#### Description

For the moment, the cover images are fetched from Moreinfo service by the "PID" key, but for some reason can be met situations when there is no response for the PID key, while the Faust number request returns data.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.