### PR TITLE
EASYOAPC-1330 - Strip DK5 from holdings.

### DIFF
--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -237,6 +237,13 @@ function fbs_settings_form() {
     '#description' => t('Allow users to delete their reservations as well as ready for pickup ones.'),
   );
 
+  $form['fbs']['fbs_display_dk5'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Display DK5 on holdings'),
+    '#description' => t('Allow to control visibility of DK5 value on holdings placement.'),
+    '#default_value' => variable_get('fbs_display_dk5', TRUE),
+  ];
+
   // Branches and blacklisted branches.
   $form['branches'] = array(
     '#type' => 'fieldset',

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -137,7 +137,6 @@ function fbs_availability_holdings($provider_ids) {
         // Look for the marc field to get DK5 classification from. We require
         // that either 'm' or 'o' subfield is present and prefer 652. If this is
         // not the case we'll try the outdated marc field 654 for DK5.
-        $field_dk5 = fbs_get_marc_field($entity, '652');
         if (empty($field_dk5['m']) && empty($field_dk5['o'])) {
           $field_dk5 = fbs_get_marc_field($entity, '654');
         }

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -137,6 +137,9 @@ function fbs_availability_holdings($provider_ids) {
         // Look for the marc field to get DK5 classification from. We require
         // that either 'm' or 'o' subfield is present and prefer 652. If this is
         // not the case we'll try the outdated marc field 654 for DK5.
+        if (variable_get('fbs_display_dk5', TRUE)) {
+          $field_dk5 = fbs_get_marc_field($entity, '652');
+        }
         if (empty($field_dk5['m']) && empty($field_dk5['o'])) {
           $field_dk5 = fbs_get_marc_field($entity, '654');
         }


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1330

#### Description

Removed the piece of code responsible for fetching the DK5 field value into holdings.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
