### PR TITLE
EASYOPAC-1341 - Translation of Staff Position.

### DIFF
--- a/modules/ding_staff/ding_staff.module
+++ b/modules/ding_staff/ding_staff.module
@@ -176,3 +176,33 @@ function ding_staff_profile2_view($profile, $view_mode, $langcode) {
     $profile->content['field_ding_staff_surname'][0]['#markup'] = $output;
   }
 }
+
+/**
+ * Implements hook_preprocess().
+ */
+function ding_staff_preprocess(&$variables, $hook) {
+  // Localization of Staff Position field.
+  // @TODO: It's wrong to pass variable into "t()" function.
+  switch ($hook) {
+    case 'entity':
+      $elements = $variables['elements'];
+      if ($elements['#entity_type'] == 'profile2' && $elements['#bundle'] == 'ding_staff_profile') {
+        if (isset($variables['content']['field_ding_staff_position'])) {
+          $staff_position = $variables['content']['field_ding_staff_position'][0]['#markup'];
+          $variables['content']['field_ding_staff_position'][0]['#markup'] = t($staff_position);
+        }
+      }
+      break;
+
+    case 'views_view_fields':
+      $view = $variables['view'];
+
+      if ($view->name == 'ding_staff') {
+        if (isset($variables["fields"]["field_ding_staff_position"])) {
+          $staff_position = $variables["fields"]["field_ding_staff_position"]->content;
+          $variables["fields"]["field_ding_staff_position"]->content = t($staff_position);
+        }
+      }
+      break;
+  }
+}

--- a/modules/ding_staff/ding_staff.module
+++ b/modules/ding_staff/ding_staff.module
@@ -182,7 +182,7 @@ function ding_staff_profile2_view($profile, $view_mode, $langcode) {
  */
 function ding_staff_preprocess(&$variables, $hook) {
   // Localization of Staff Position field.
-  // @todo: It's wrong to pass variable into "t()" function.
+  // @todo It's wrong to pass variable into "t()" function.
   switch ($hook) {
     case 'entity':
       $elements = $variables['elements'];
@@ -198,9 +198,9 @@ function ding_staff_preprocess(&$variables, $hook) {
       $view = $variables['view'];
 
       if ($view->name == 'ding_staff') {
-        if (isset($variables["fields"]["field_ding_staff_position"])) {
-          $staff_position = $variables["fields"]["field_ding_staff_position"]->content;
-          $variables["fields"]["field_ding_staff_position"]->content = t($staff_position);
+        if (isset($variables['fields']['field_ding_staff_position'])) {
+          $staff_position = $variables['fields']['field_ding_staff_position']->content;
+          $variables['fields']['field_ding_staff_position']->content = t($staff_position);
         }
       }
       break;

--- a/modules/ding_staff/ding_staff.module
+++ b/modules/ding_staff/ding_staff.module
@@ -182,7 +182,7 @@ function ding_staff_profile2_view($profile, $view_mode, $langcode) {
  */
 function ding_staff_preprocess(&$variables, $hook) {
   // Localization of Staff Position field.
-  // @TODO: It's wrong to pass variable into "t()" function.
+  // @todo: It's wrong to pass variable into "t()" function.
   switch ($hook) {
     case 'entity':
       $elements = $variables['elements'];


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1341

#### Description

Because of profile2 entity specific behavior which is not allowing field values translation, process the 'position' field with `t()` function.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.