### PR TITLE
EASYOPAC-1336 - Add easyopac_marc_references module to make file.

### DIFF
--- a/easyopac.make
+++ b/easyopac.make
@@ -376,6 +376,13 @@ projects[easyopac_abstracts_override][download][url]    = "git@github.com:easySu
 ;projects[easyopac_abstracts_override][download][tag]    = ""
 projects[easyopac_abstracts_override][download][branch] = "development"
 
+projects[easyopac_marc_references][type]             = "module"
+projects[easyopac_marc_references][subdir]           = ""
+projects[easyopac_marc_references][download][type]   = "git"
+projects[easyopac_marc_references][download][url]    = "git@github.com:easySuite/easyopac_marc_references.git"
+;projects[easyopac_marc_references][download][tag]    = ""
+projects[easyopac_marc_references][download][branch] = "development"
+
 projects[easyddb_event_status][type]             = "module"
 projects[easyddb_event_status][subdir]           = ""
 projects[easyddb_event_status][download][type]   = "git"


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1336

#### Description

Add custom `easyopac_marc_references` module into make file.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.