### PR TITLE
EASYOPAC-1327 - Wrong sorting order for events.

### DIFF
--- a/project.make
+++ b/project.make
@@ -639,7 +639,7 @@ libraries[html5shiv][destination] = "libraries"
 
 ; For ding_libs.
 libraries[masonry][download][type] = "get"
-libraries[masonry][download][url] = https://github.com/desandro/masonry/archive/v4.1.1.zip
+libraries[masonry][download][url] = https://github.com/desandro/masonry/archive/v4.2.2.zip
 libraries[masonry][directory_name] = "masonry"
 libraries[masonry][destination] = "libraries"
 

--- a/themes/ddbasic/scripts/view.js
+++ b/themes/ddbasic/scripts/view.js
@@ -57,6 +57,7 @@
             itemSelector: '.views-row',
             columnWidth: '.grid-sizer',
             gutter: '.grid-gutter',
+            horizontalOrder: true,
             percentPosition: true
           })
             .on('layoutComplete', function () {
@@ -255,6 +256,7 @@
           itemSelector: '.views-row',
           columnWidth: '.grid-sizer',
           gutter: '.grid-gutter',
+          horizontalOrder: true,
           percentPosition: true
         });
          $msnry.on('layoutComplete', function (items) {


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1327

#### Description

Updating Masonry JS library to the latest version which introduces ordering of grid items and add `horizontalOrder` property to ding event list view.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.