### PR TITLE
EASYOPAC-1368 - Sorting by event date breaks the site.

### DIFF
--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1842,6 +1842,12 @@ function ding_nodelist_preprocess(&$variables, $hook) {
   // Making currency available for all nodelist events.
   if (strpos($hook, 'ding_nodelist') !== FALSE) {
     $items = !empty($variables['items']) ? $variables['items'] : array();
+    // Loop through sorted by date items and extract objects.
+    foreach ($items as $key => $item) {
+      if (!is_object($item)) {
+        $items[$key] = reset($item);
+      }
+    }
     if (!empty($items)) {
       foreach ((array) $items as $key => $item) {
         $author = l($item->name, 'user/' . $item->uid);

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.slider.tpl.php
@@ -14,7 +14,7 @@
   </div>
   <div class="node">
     <div class="item-date">
-      <?php print drupal_render($item->formated_date); ?>
+      <?php print $item->formated_date; ?>
     </div>
     <div class="event-details">
       <span class="library"><?php print drupal_render($item->library_link); ?></span>


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1368

#### Description

In case of items sorting by events date, the node object is wrapped into an array item with event date timestamp as a key for further sorting and when it comes the time for rendering the node object is not found and page fails to load with critical error.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.