### PR TITLE
EASYOPAC-1404 - Error label on user loans overlap material info.

### DIFF
--- a/themes/ddbasic/sass/components/form/form-status.scss
+++ b/themes/ddbasic/sass/components/form/form-status.scss
@@ -14,10 +14,7 @@
 
   > div {
     > .select-all {
-      position: relative;
-      float: left;
       width: 100%;
-      float: left;
       padding: 23px 20px;
       margin: 10px 0;
       background-color: $grey-dark;
@@ -28,8 +25,10 @@
       .form-item {
         margin: 0;
         color: $white;
+
         &.form-disabled {
-          label::before {
+          label::before,
+          input[disabled="disabled"] {
             visibility: hidden;
           }
         }

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -136,12 +136,8 @@
 
   // Specific style for messages on material item
   .messages {
-    position: absolute;
-    top: 16px;
-    right: 0;
-    width: 190px;
     padding: 10px;
-    margin: 0;
+    margin: 0 0 10px 0;
     background-image: none;
     color: $white;
     border: 0;

--- a/themes/ddbasic/templates/material-item.tpl.php
+++ b/themes/ddbasic/templates/material-item.tpl.php
@@ -18,14 +18,16 @@
     <?php print $cover; ?>
   </div>
   <div class="right-column">
+    <?php if (isset($material_message)) : ?>
+      <div class="<?php print $material_message['class']; ?>"><?php print $material_message['message']; ?></div>
+    <?php endif; ?>
     <?php if (!empty($material_type)) : ?>
       <div class="item-material-type"><?php print $material_type; ?></div>
     <?php endif; ?>
-    <h3 id="<?php print $availability_id; ?>" class="item-title<?php if (isset($material_message)) : ?> has-message <?php
-   endif; ?>"><?php print $title; ?></h3>
-   <?php if (!empty($creators)) : ?>
-     <div class="item-creators"><?php print $creators; ?></div>
-   <?php endif; ?>
+    <h3 id="<?php print $availability_id; ?>" class="item-title<?php if (isset($material_message)) : ?> has-message <?php endif; ?>"><?php print $title; ?></h3>
+    <?php if (!empty($creators)) : ?>
+      <div class="item-creators"><?php print $creators; ?></div>
+    <?php endif; ?>
 
     <ul class="item-information-list">
       <?php foreach ($information as $info) : ?>
@@ -37,8 +39,5 @@
         </li>
       <?php endforeach; ?>
     </ul>
-    <?php if (isset($material_message)) : ?>
-    <div class="<?php print $material_message['class']; ?>"><?php print $material_message['message']; ?></div>
-    <?php endif; ?>
   </div>
 </div>


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1404

#### Description

Error label overlaps materiale number for some materials on desktop on the user loans page.

#### Screenshot of the result
![Screenshot 2022-05-26 at 16 02 03](https://user-images.githubusercontent.com/800338/170492861-d64994ec-bf36-4056-99cb-68c51cbfe85e.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
