### PR TITLE
EASYOPAC-1407 - Retrive covers by faust number also.

### DIFF
--- a/modules/ting_covers_addi/lib/addi-client/AdditionalInformationService.php
+++ b/modules/ting_covers_addi/lib/addi-client/AdditionalInformationService.php
@@ -105,7 +105,13 @@ class AdditionalInformationService {
       }
       // Otherwise, just map the ID type to the ID number.
       else {
-        $identifiers[] = array($id_type => $id);
+        if ($id_type === 'faust') {
+          $faust_parts = explode(':', $id);
+          $identifiers[] = [$id_type => $faust_parts[1]];
+        }
+        else {
+          $identifiers[] = [$id_type => $id];
+        }
       }
     }
 

--- a/modules/ting_covers_addi/ting_covers_addi.admin.inc
+++ b/modules/ting_covers_addi/ting_covers_addi.admin.inc
@@ -66,6 +66,13 @@ function ting_covers_addi_admin_settings_form($form, &$form_state) {
     '#default_value' => variable_get('ting_covers_addi_enforce_url', FALSE),
   );
 
+  $form['addi']['ting_covers_addi_request_by_faust'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Request covers by Faust number'),
+    '#description' => t('By default covers are requested by their PID identifiers. By enabling this option the covers will be requested by their Faust number.'),
+    '#default_value' => variable_get('ting_covers_addi_request_by_faust', FALSE),
+  ];
+
   $form['addi']['external_url'] = array(
     '#type' => 'fieldset',
     '#title' => t('External URL'),

--- a/modules/ting_covers_addi/ting_covers_addi.module
+++ b/modules/ting_covers_addi/ting_covers_addi.module
@@ -43,7 +43,8 @@ function ting_covers_addi_ding_install_tasks() {
  * Fetch covers from AdditionalInformation service.
  */
 function ting_covers_addi_ting_covers($entities) {
-  $covers = array();
+  $covers = [];
+  $retrieved = [];
 
   // Exceptions should only be thrown if something is so wrong,
   // that no images can be fetched whatsoever.
@@ -51,9 +52,20 @@ function ting_covers_addi_ting_covers($entities) {
     $service = new AdditionalInformationService(variable_get('ting_covers_addi_wsdl_url'), variable_get('ting_covers_addi_username'), variable_get('ting_covers_addi_group'), variable_get('ting_covers_addi_password'), variable_get('ting_covers_addi_enforce_url', FALSE));
 
     // Retrieve covers by PID.
-    $retrieved = $service->getByPid(array_keys($entities));
+    $retrieved += $service->getByPid(array_keys($entities));
+    // Retrieve covers by Faust.
+    $retrieved += $service->getByFaustNumber(array_keys($entities));
 
-    foreach ($retrieved as $pid=> $cover) {
+    // Since the faust number is only the numeric part of PID, need to normalize
+    // (translate fausts to PID) the retrieved data in order to have covers
+    // rendered.
+    foreach (array_keys($entities) as $ding_entity_id) {
+      $parts = explode(':', $ding_entity_id);
+      $retrieved[$ding_entity_id] = $retrieved[$parts[1]];
+      unset($retrieved[$parts[1]]);
+    }
+
+    foreach ($retrieved as $pid => $cover) {
       // Try to extract the image url from the result.
       $source_url = FALSE;
       if ($cover->detailUrl) {
@@ -79,10 +91,10 @@ function ting_covers_addi_ting_covers($entities) {
     }
   }
   catch (Exception $e) {
-    watchdog('ting_covers_addi', 'Unable to retrieve covers from ADDI: %message', array('%message' => $e->getMessage()), WATCHDOG_ERROR);
+    watchdog('ting_covers_addi', 'Unable to retrieve covers from ADDI: %message', ['%message' => $e->getMessage()], WATCHDOG_ERROR);
 
     // Error in fetching, return no covers.
-    return array();
+    return [];
   }
 
   // Return all image information.

--- a/modules/ting_covers_addi/ting_covers_addi.module
+++ b/modules/ting_covers_addi/ting_covers_addi.module
@@ -51,18 +51,22 @@ function ting_covers_addi_ting_covers($entities) {
   try {
     $service = new AdditionalInformationService(variable_get('ting_covers_addi_wsdl_url'), variable_get('ting_covers_addi_username'), variable_get('ting_covers_addi_group'), variable_get('ting_covers_addi_password'), variable_get('ting_covers_addi_enforce_url', FALSE));
 
-    // Retrieve covers by PID.
-    $retrieved += $service->getByPid(array_keys($entities));
-    // Retrieve covers by Faust.
-    $retrieved += $service->getByFaustNumber(array_keys($entities));
+    if (variable_get('ting_covers_addi_request_by_faust', FALSE)) {
+      // Retrieve covers by Faust.
+      $retrieved += $service->getByFaustNumber(array_keys($entities));
 
-    // Since the faust number is only the numeric part of PID, need to normalize
-    // (translate fausts to PID) the retrieved data in order to have covers
-    // rendered.
-    foreach (array_keys($entities) as $ding_entity_id) {
-      $parts = explode(':', $ding_entity_id);
-      $retrieved[$ding_entity_id] = $retrieved[$parts[1]];
-      unset($retrieved[$parts[1]]);
+      // Since the faust number is only the numeric part of PID, need to normalize
+      // (translate Faust number to PID) the retrieved data in order to have covers
+      // rendered.
+      foreach (array_keys($entities) as $ding_entity_id) {
+        $parts = explode(':', $ding_entity_id);
+        $retrieved[$ding_entity_id] = $retrieved[$parts[1]];
+        unset($retrieved[$parts[1]]);
+      }
+    }
+    else {
+      // Retrieve covers by PID.
+      $retrieved += $service->getByPid(array_keys($entities));
     }
 
     foreach ($retrieved as $pid => $cover) {


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1407

#### Description
By default, covers are retrieved on the PID of record basis, this PR also adds successive request by Faust number and merges the result with result of first request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.