### PR TITLE
IN-110 - Block indexing of staging sites.

### DIFF
--- a/easyopac.make
+++ b/easyopac.make
@@ -633,3 +633,9 @@ projects[easyopac_redirect][download][type]   = "git"
 projects[easyopac_redirect][download][url]    = "git@github.com:easySuite/easyopac_redirect.git"
 ;projects[easyopac_redirect][download][tag]    = ""
 projects[easyopac_redirect][download][branch] = "development"
+
+; Other modules (narrowly focused)
+projects[inlead_forbid_crawling][type]                = "module"
+projects[inlead_forbid_crawling][download][type]      = "git"
+projects[inlead_forbid_crawling][download][url]       = "git@github.com:inleadmedia/inlead_forbid_crawling.git"
+projects[inlead_forbid_crawling][download][branch]    = "development"


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/IN-110

#### Description

Adds custom module which enabled will overwrite the default robots.txt file content with crawlers blocking instructions and will also add `<meta name="robots" content="noindex, nofollow">` meta tag into the site header.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.