### PR TITLE
EASYOPAC-1410 - Adapt IPE custom content banner for small devices.

### DIFF
--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -396,12 +396,6 @@ function ding_ipe_filter_preprocess_panels_pane(&$variables) {
     $conf = $pane->configuration;
 
     $styles = [
-      'text-align: center',
-      'text-transform: uppercase',
-      'height: 80px',
-      'line-height: 80px',
-      'font-size: 24px',
-      'font-weight: 700',
       'background-color: ' . $conf['banner_bg_color'],
       'color: ' . $conf['banner_text_color'],
     ];
@@ -409,6 +403,7 @@ function ding_ipe_filter_preprocess_panels_pane(&$variables) {
     $container = [
       '#type' => 'container',
       '#attributes' => [
+        'class' => ['ding-ipe-filter--banner-mode'],
         'style' => implode(';', $styles),
       ],
       'text' => [

--- a/themes/ddbasic/ddbasic.info
+++ b/themes/ddbasic/ddbasic.info
@@ -73,6 +73,7 @@
 
   stylesheets[all][] = sass_css/module/christmas_calendar.css
   stylesheets[all][] = sass_css/module/ding_toggle.css
+  stylesheets[all][] = sass_css/module/ding_ipe_filter.css
 
   stylesheets[all][] = sass_css/add-ons/factbox.css
   stylesheets[all][] = sass_css/add-ons/frontpage-header.css

--- a/themes/ddbasic/sass/module/ding_ipe_filter.scss
+++ b/themes/ddbasic/sass/module/ding_ipe_filter.scss
@@ -1,0 +1,20 @@
+.ding-ipe-filter {
+  &--banner-mode {
+    text-align: center;
+    text-transform: uppercase;
+    height: auto;
+    line-height: 80px;
+    font-size: 24px;
+    font-weight: 700;
+
+    @media (max-width: 768px) {
+      font-size: 18px;
+      line-height: 32px;
+      font-weight: 600;
+
+      p {
+        padding: 15px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1410

#### Description

Moved inline styles into separate css file and added some styles modifications for smaller devices.

#### Screenshot of the result

![eo localhost_(iPhone 12 Pro)](https://user-images.githubusercontent.com/800338/180452025-afa3f8b5-7ff8-41c8-92a2-1dcd86776beb.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
