### PR TITLE
EASYOPAC-1380 - Revert changes to search.scss

### DIFF
--- a/themes/ddbasic/sass/components/search.scss
+++ b/themes/ddbasic/sass/components/search.scss
@@ -52,12 +52,6 @@
       }
     }
   }
- #ding-facetbrowser-form .form-checkboxes .form-item {
-    margin-top: 0;
-    margin-bottom: 15px;
-    text-transform: capitalize;
-  }
-
 }
 
 


### PR DESCRIPTION
#### Link to issue

https://inlead.atlassian.net/browse/EASYOPAC-1380

#### Description

EO-1380 introduces changes to search.scss that had unintended consequences for search page, making all facets capitalized. This reverts the change, but leaves in other changes intact.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
