### PR TITLE
EASYOPAC-1463 - Added attribute for search input.

### DIFF
--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -204,6 +204,9 @@ function ting_search_form_search_block_form_alter(&$form, &$form_state, $form_id
   // Set the placeholder.
   $form['search_block_form']['#attributes']['placeholder'] = t('Search the library');
 
+  // Set the aria-label.
+  //$form['search_block_form']['#attributes']['aria-label'] = t('Search the library');
+
   $form['sort'] = array(
     '#type' => 'hidden',
     '#default_value' => isset($_GET['sort']) ? check_plain($_GET['sort']) : FALSE,

--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -205,7 +205,7 @@ function ting_search_form_search_block_form_alter(&$form, &$form_state, $form_id
   $form['search_block_form']['#attributes']['placeholder'] = t('Search the library');
 
   // Set the aria-label.
-  //$form['search_block_form']['#attributes']['aria-label'] = t('Search the library');
+  $form['search_block_form']['#attributes']['aria-label'] = t('Search the library');
 
   $form['sort'] = array(
     '#type' => 'hidden',


### PR DESCRIPTION
#### Link to issue
https://inlead.atlassian.net/browse/EASYOPAC-1463

#### Description
Added the aria-label attribute for search input. It was needed for auto-tests WCAG.

#### Screenshot of the result
![image](https://github.com/easySuite/ding2/assets/8419717/54beb04f-b60f-4c46-9f8b-dc002cdfb556)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
